### PR TITLE
Bruk telefon fra pdl hvis det ikke finnes i krr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,10 @@ repositories {
 
 val commonVersion = "3.2023.05.02_06.50-0576b4e09008"
 val okhttp3Version = "4.11.0"
-val kotestVersion = "5.6.1"
+val kotestVersion = "5.6.2"
 val poaoTilgangVersion = "2023.05.02_09.15-64228b754508"
-val testcontainersVersion = "1.18.0"
-val tokenSupportVersion = "3.0.11"
+val testcontainersVersion = "1.18.1"
+val tokenSupportVersion = "3.0.12"
 val mockkVersion = "1.13.5"
 val lang3Version = "3.12.0"
 val shedlockVersion = "5.2.0"

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
@@ -85,11 +85,11 @@ class PdlClient(
 		}
 	}
 
-	fun hentAdressebeskyttelse(ident: String): AdressebeskyttelseGradering? {
+	fun hentTelefon(ident: String): String? {
 		val requestBody = toJsonString(
 			GraphqlUtils.GraphqlQuery(
-				PdlQueries.HentAdressebeskyttelse.query,
-				PdlQueries.HentAdressebeskyttelse.Variables(ident)
+				PdlQueries.HentTelefon.query,
+				PdlQueries.HentTelefon.Variables(ident)
 			)
 		)
 
@@ -102,7 +102,7 @@ class PdlClient(
 
 			val body = response.body?.string() ?: throw RuntimeException("Body is missing from PDL request")
 
-			val gqlResponse = fromJsonString<PdlQueries.HentAdressebeskyttelse.Response>(body)
+			val gqlResponse = fromJsonString<PdlQueries.HentTelefon.Response>(body)
 
 			throwPdlApiErrors(gqlResponse)
 			logPdlWarnings(gqlResponse.extensions?.warnings)
@@ -111,7 +111,7 @@ class PdlClient(
 				throw RuntimeException("PDL respons inneholder ikke data")
 			}
 
-			return getDiskresjonskode(gqlResponse.data.hentPerson.adressebeskyttelse)
+			return getTelefonnummer(gqlResponse.data.hentPerson.telefonnummer)
 		}
 	}
 
@@ -141,13 +141,13 @@ class PdlClient(
 
 	}
 
-	private fun getTelefonnummer(telefonnummere: List<PdlQueries.HentPerson.Telefonnummer>): String? {
+	private fun getTelefonnummer(telefonnummere: List<PdlQueries.Telefonnummer>): String? {
 		val prioritertNummer = telefonnummere.minByOrNull { it.prioritet } ?: return null
 
 		return "${prioritertNummer.landskode} ${prioritertNummer.nummer}"
 	}
 
-	private fun getDiskresjonskode(adressebeskyttelse: List<PdlQueries.Adressebeskyttelse>): AdressebeskyttelseGradering? {
+	private fun getDiskresjonskode(adressebeskyttelse: List<PdlQueries.HentPerson.Adressebeskyttelse>): AdressebeskyttelseGradering? {
 		return when(adressebeskyttelse.firstOrNull()?.gradering) {
 			"STRENGT_FORTROLIG_UTLAND" -> AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
 			"STRENGT_FORTROLIG" -> AdressebeskyttelseGradering.STRENGT_FORTROLIG

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
@@ -35,11 +35,11 @@ object PdlQueries {
 		val warnings: List<PdlWarning>
 	)
 
-	data class Adressebeskyttelse(
-		val gradering: String
+	data class Telefonnummer(
+		val landskode: String,
+		val nummer: String,
+		val prioritet: Int,
 	)
-
-
 	object HentPerson {
 		val query = """
 			query(${"$"}ident: ID!) {
@@ -95,12 +95,6 @@ object PdlQueries {
 			val etternavn: String,
 		)
 
-		data class Telefonnummer(
-			val landskode: String,
-			val nummer: String,
-			val prioritet: Int,
-		)
-
 		data class HentIdenter(
 			val identer: List<Ident>
 		)
@@ -111,14 +105,19 @@ object PdlQueries {
 			val gruppe: String
 		)
 
+		data class Adressebeskyttelse(
+			val gradering: String
+		)
 	}
 
-	object HentAdressebeskyttelse {
+	object HentTelefon {
 		val query = """
 			query(${"$"}ident: ID!) {
 			  hentPerson(ident: ${"$"}ident) {
-				adressebeskyttelse(historikk: false) {
-				  gradering
+				telefonnummer {
+				  landskode
+				  nummer
+				  prioritet
 				}
 			  },
 			}
@@ -135,11 +134,11 @@ object PdlQueries {
 		) : GraphqlUtils.GraphqlResponse<ResponseData, PdlErrorExtension>
 
 		data class ResponseData(
-			val hentPerson: HentAdressebeskyttelse
+			val hentPerson: HentPerson
 		)
 
-		data class HentAdressebeskyttelse(
-			val adressebeskyttelse: List<Adressebeskyttelse>
+		data class HentPerson(
+			val telefonnummer: List<Telefonnummer>
 		)
 
 	}

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
@@ -11,6 +11,7 @@ import no.nav.amt.person.service.person.PersonService
 import no.nav.amt.person.service.person.RolleService
 import no.nav.amt.person.service.person.model.Person
 import no.nav.amt.person.service.person.model.Rolle
+import no.nav.amt.person.service.person.model.erBeskyttet
 import no.nav.poao_tilgang.client.PoaoTilgangClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -45,7 +46,7 @@ class NavBrukerService(
 	private fun opprettNavBruker(personIdent: String): NavBruker {
 		val personOpplysninger = pdlClient.hentPerson(personIdent)
 
-		if (personService.erAdressebeskyttet(personOpplysninger.adressebeskyttelseGradering)) {
+		if (personOpplysninger.adressebeskyttelseGradering.erBeskyttet()) {
 			throw IllegalStateException("Nav bruker er adreessebeskyttet og kan ikke lagres")
 		}
 

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
@@ -3,7 +3,6 @@ package no.nav.amt.person.service.person
 import no.nav.amt.person.service.clients.pdl.PdlClient
 import no.nav.amt.person.service.clients.pdl.PdlPerson
 import no.nav.amt.person.service.config.SecureLog.secureLog
-import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
 import no.nav.amt.person.service.person.model.IdentType
 import no.nav.amt.person.service.person.model.Person
 import org.slf4j.LoggerFactory
@@ -39,10 +38,6 @@ class PersonService(
 
 
 	fun hentGjeldendeIdent(personIdent: String) = pdlClient.hentGjeldendePersonligIdent(personIdent)
-
-	fun erAdressebeskyttet(gradering: AdressebeskyttelseGradering?): Boolean {
-		return gradering != null && gradering != AdressebeskyttelseGradering.UGRADERT
-	}
 
 	fun oppdaterPersonIdent(gjeldendeIdent: String, identType: IdentType, historiskeIdenter: List<String>) {
 		val personer = repository.getPersoner(historiskeIdenter.plus(gjeldendeIdent))

--- a/src/main/kotlin/no/nav/amt/person/service/person/model/AdressebeskyttelseGradering.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/model/AdressebeskyttelseGradering.kt
@@ -6,3 +6,7 @@ enum class AdressebeskyttelseGradering {
 	STRENGT_FORTROLIG_UTLAND,
 	UGRADERT,
 }
+
+fun AdressebeskyttelseGradering?.erBeskyttet(): Boolean {
+	return this != AdressebeskyttelseGradering.UGRADERT && this != null
+}

--- a/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTest.kt
@@ -2,14 +2,12 @@ package no.nav.amt.person.service.clients.pdl
 
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.shouldBe
-import no.nav.amt.person.service.clients.pdl.PdlClientTestData.adressebeskyttetResponseMedWarning
 import no.nav.amt.person.service.clients.pdl.PdlClientTestData.errorPrefix
 import no.nav.amt.person.service.clients.pdl.PdlClientTestData.flereFeilRespons
 import no.nav.amt.person.service.clients.pdl.PdlClientTestData.gyldigRespons
 import no.nav.amt.person.service.clients.pdl.PdlClientTestData.minimalFeilRespons
 import no.nav.amt.person.service.clients.pdl.PdlClientTestData.nullError
-import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
-import no.nav.amt.person.service.utils.LogUtils
+import no.nav.amt.person.service.clients.pdl.PdlClientTestData.telefonResponse
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -219,32 +217,17 @@ class PdlClientTest {
 	}
 
 	@Test
-	fun `hentAdressebeskyttelse - person har adressebeskyttelse - returnerer gradering`() {
+	fun `hentTelefon - person har telefon - returnerer telefon`() {
 		val client = PdlClient(
 			serverUrl,
 			{ "TOKEN" },
 		)
 
-		server.enqueue(MockResponse().setBody(adressebeskyttetResponseMedWarning))
+		server.enqueue(MockResponse().setBody(telefonResponse))
 
-		val gradering = client.hentAdressebeskyttelse("FNR")
+		val telefon = client.hentTelefon("FNR")
 
-		gradering shouldBe AdressebeskyttelseGradering.FORTROLIG
-	}
-
-	@Test
-	fun `hentAdressebeskyttelse - warnings i respons - skal logge warnings`() {
-		val client = PdlClient(
-			serverUrl,
-			{ "TOKEN" },
-		)
-
-		server.enqueue(MockResponse().setBody(adressebeskyttetResponseMedWarning))
-
-		LogUtils.withLogs { getLogs ->
-			client.hentAdressebeskyttelse("FNR")
-			getLogs().any { it.message.startsWith("Respons fra Pdl inneholder warnings:")} shouldBe true
-		}
+		telefon shouldBe "+47 12345678"
 	}
 
 }

--- a/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTestData.kt
@@ -106,13 +106,20 @@ object PdlClientTestData {
 		}
 	""".trimIndent()
 
-	val adressebeskyttetResponseMedWarning = """
+	val telefonResponse = """
 		{
 		  "data": {
 		    "hentPerson": {
-				"adressebeskyttelse": [
+				"telefonnummer": [
 					{
-						"gradering": "FORTROLIG"
+						"landskode": "+47",
+						"nummer": "98765432",
+						"prioritet": 2
+					},
+					{
+						"landskode": "+47",
+						"nummer": "12345678",
+						"prioritet": 1
 					}
 				]
 		    }

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -1,10 +1,13 @@
 package no.nav.amt.person.service.data
 
-import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
+import no.nav.amt.person.service.clients.pdl.PdlPerson
+import no.nav.amt.person.service.clients.pdl.PdlPersonIdent
 import no.nav.amt.person.service.nav_ansatt.NavAnsattDbo
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
-import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
+import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
+import no.nav.amt.person.service.person.model.IdentType
 import java.time.LocalDateTime
 import java.util.*
 
@@ -81,4 +84,17 @@ object TestData {
 		modifiedAt: LocalDateTime = LocalDateTime.now(),
 	) = NavBrukerDbo(id, person, navVeileder, navEnhet, telefon, epost, erSkjermet, createdAt, modifiedAt)
 
+	fun lagPdlPerson(
+		person: PersonDbo,
+		telefon: String? = null,
+		adressebeskyttelseGradering: AdressebeskyttelseGradering? = null,
+		identer: List<PdlPersonIdent> = listOf(PdlPersonIdent(person.personIdent, false, "FOLKEREGISTERET")),
+	) = PdlPerson(
+		fornavn = person.fornavn,
+		mellomnavn = person.mellomnavn,
+		etternavn = person.etternavn,
+		telefonnummer = telefon,
+		adressebeskyttelseGradering = adressebeskyttelseGradering,
+		identer = identer,
+	)
 }

--- a/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
@@ -41,7 +41,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		val person = TestData.lagPerson()
 		val token = mockOAuthServer.issueAzureAdM2MToken()
 
-		mockPdlHttpServer.mockHentPerson(person.toModel())
+		mockPdlHttpServer.mockHentPerson(person)
 
 		val response = sendRequest(
 			method = "POST",
@@ -68,8 +68,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		val navEnhet = TestData.lagNavEnhet()
 		val navBruker = TestData.lagNavBruker(navVeileder = navAnsatt, navEnhet = navEnhet)
 
-		mockPdlHttpServer.mockHentAdressebeskyttelse(navBruker.person.personIdent, AdressebeskyttelseGradering.UGRADERT)
-		mockPdlHttpServer.mockHentPerson(navBruker.person.toModel())
+		mockPdlHttpServer.mockHentPerson(navBruker.person)
 		mockVeilarboppfolgingHttpServer.mockHentVeilederIdent(navBruker.person.personIdent, navAnsatt.navIdent)
 		mockVeilarbarenaHttpServer.mockHentBrukerOppfolgingsenhetId(navBruker.person.personIdent, navEnhet.enhetId)
 		mockKrrProxyHttpServer.mockHentKontaktinformasjon(MockKontaktinformasjon(navBruker.epost, navBruker.telefon))
@@ -108,9 +107,12 @@ class PersonControllerTest: IntegrationTestBase() {
 	fun `hentEllerOpprettNavBruker - nav bruker er adressebeskyttet - skal ha status 500`() {
 		val navBruker = TestData.lagNavBruker()
 
-		mockPdlHttpServer.mockHentAdressebeskyttelse(
+		mockPdlHttpServer.mockHentPerson(
 			navBruker.person.personIdent,
-			AdressebeskyttelseGradering.STRENGT_FORTROLIG
+			TestData.lagPdlPerson(
+				person = navBruker.person,
+				adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG
+			)
 		)
 
 		val response = sendRequest(

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
@@ -41,6 +41,7 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		val nyTelefon = "+12345678"
 
 		mockKrrProxyHttpServer.mockHentKontaktinformasjon(MockKontaktinformasjon(nyEpost, nyTelefon))
+		mockPdlHttpServer.mockHentTelefon(person.personIdent, null)
 
 		val msg = KafkaMessageCreator.lagPersonhendelseNavn(
 			personIdenter = listOf(person.personIdent),

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
@@ -1,8 +1,9 @@
 package no.nav.amt.person.service.integration.mock.servers
 
+import no.nav.amt.person.service.clients.pdl.PdlPerson
 import no.nav.amt.person.service.clients.pdl.PdlQueries
-import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
-import no.nav.amt.person.service.person.model.Person
+import no.nav.amt.person.service.data.TestData
+import no.nav.amt.person.service.person.dbo.PersonDbo
 import no.nav.amt.person.service.utils.GraphqlUtils
 import no.nav.amt.person.service.utils.JsonUtils.toJsonString
 import no.nav.amt.person.service.utils.MockHttpServer
@@ -12,14 +13,10 @@ import okhttp3.mockwebserver.RecordedRequest
 
 class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 
-	fun mockHentPerson(person: Person) {
-		mockHentPerson(person.personIdent, MockPdlBruker(
-			fornavn = person.fornavn,
-			etternavn = person.etternavn,
-			adressebeskyttelse = null,
-		))
+	fun mockHentPerson(person: PersonDbo) {
+		mockHentPerson(person.personIdent, TestData.lagPdlPerson(person))
 	}
-	fun mockHentPerson(brukerFnr: String, mockPdlBruker: MockPdlBruker) {
+	fun mockHentPerson(brukerFnr: String, mockPdlPerson: PdlPerson) {
 		val request = toJsonString(
 				GraphqlUtils.GraphqlQuery(
 					PdlQueries.HentPerson.query,
@@ -33,7 +30,7 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 				&& req.getBodyAsString() == request
 		}
 
-		addResponseHandler(requestPredicate, createPdlBrukerResponse(brukerFnr, mockPdlBruker))
+		addResponseHandler(requestPredicate, createPdlBrukerResponse(brukerFnr, mockPdlPerson))
 	}
 
 	fun mockHentGjeldendePersonligIdent(ident: String, personIdent: String) {
@@ -53,11 +50,11 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 		addResponseHandler(requestPredicate, createHentGjeldendeIdentResponse(personIdent))
 	}
 
-	fun mockHentAdressebeskyttelse(ident: String, gradering: AdressebeskyttelseGradering) {
+	fun mockHentTelefon(ident: String, telefon: String?) {
 		val request = toJsonString(
 			GraphqlUtils.GraphqlQuery(
-				PdlQueries.HentAdressebeskyttelse.query,
-				PdlQueries.HentAdressebeskyttelse.Variables(ident)
+				PdlQueries.HentTelefon.query,
+				PdlQueries.HentTelefon.Variables(ident)
 			)
 		)
 
@@ -67,7 +64,25 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 				&& req.getBodyAsString() == request
 		}
 
-		addResponseHandler(requestPredicate, createPdlAdressebeskyttelseResponse(gradering))
+		addResponseHandler(requestPredicate, createHentTelefonResponse(telefon))
+	}
+
+	private fun createHentTelefonResponse(telefon: String?): MockResponse {
+		val telefonnummer = telefon?.let { listOf(PdlQueries.Telefonnummer("47", it, 1)) } ?: emptyList()
+
+		val body = toJsonString(
+			PdlQueries.HentTelefon.Response(
+				errors = null,
+				data = PdlQueries.HentTelefon.ResponseData(
+					PdlQueries.HentTelefon.HentPerson(
+						telefonnummer = telefonnummer
+					)
+				),
+				extensions = null,
+			)
+		)
+
+		return MockResponse().setResponseCode(200).setBody(body)
 	}
 
 
@@ -87,16 +102,16 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 		return MockResponse().setResponseCode(200).setBody(body)
 	}
 
-	private fun createPdlBrukerResponse(personIdent: String, mockPdlBruker: MockPdlBruker): MockResponse {
+	private fun createPdlBrukerResponse(personIdent: String, mockPdlPerson: PdlPerson): MockResponse {
 		val body = toJsonString(
 			PdlQueries.HentPerson.Response(
 				errors = null,
 				data = PdlQueries.HentPerson.ResponseData(
 					PdlQueries.HentPerson.HentPerson(
-						navn = listOf(PdlQueries.HentPerson.Navn(mockPdlBruker.fornavn, null, mockPdlBruker.etternavn)),
-						telefonnummer = listOf(PdlQueries.HentPerson.Telefonnummer("47", "12345678", 1)),
-						adressebeskyttelse = if (mockPdlBruker.adressebeskyttelse != null) {
-							listOf(PdlQueries.Adressebeskyttelse(mockPdlBruker.adressebeskyttelse.name))
+						navn = listOf(PdlQueries.HentPerson.Navn(mockPdlPerson.fornavn, null, mockPdlPerson.etternavn)),
+						telefonnummer = listOf(PdlQueries.Telefonnummer("47", "12345678", 1)),
+						adressebeskyttelse = if (mockPdlPerson.adressebeskyttelseGradering != null) {
+							listOf(PdlQueries.HentPerson.Adressebeskyttelse(gradering = mockPdlPerson.adressebeskyttelseGradering.toString()))
 						} else {
 							emptyList()
 						}
@@ -112,27 +127,4 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 			.setBody(body)
 	}
 
-	private fun createPdlAdressebeskyttelseResponse(gradering: AdressebeskyttelseGradering): MockResponse {
-		val body = toJsonString(
-			PdlQueries.HentAdressebeskyttelse.Response(
-				errors = null,
-				data = PdlQueries.HentAdressebeskyttelse.ResponseData(
-					PdlQueries.HentAdressebeskyttelse.HentAdressebeskyttelse(
-						listOf(PdlQueries.Adressebeskyttelse(gradering.name))
-					)
-				),
-				extensions = null,
-			)
-		)
-
-		return MockResponse()
-			.setResponseCode(200)
-			.setBody(body)
-	}
 }
-
-data class MockPdlBruker(
-	val fornavn: String = "Ola",
-	val etternavn: String = "Nordmann",
-	val adressebeskyttelse: AdressebeskyttelseGradering? = null,
-)

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
@@ -6,11 +6,13 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.amt.person.service.clients.krr.Kontaktinformasjon
 import no.nav.amt.person.service.clients.krr.KrrProxyClient
+import no.nav.amt.person.service.clients.pdl.PdlClient
 import no.nav.amt.person.service.data.TestData
 import no.nav.amt.person.service.nav_ansatt.NavAnsattService
 import no.nav.amt.person.service.nav_enhet.NavEnhetService
 import no.nav.amt.person.service.person.PersonService
 import no.nav.amt.person.service.person.RolleService
+import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
 import no.nav.amt.person.service.person.model.Rolle
 import no.nav.poao_tilgang.client.PoaoTilgangClient
 import no.nav.poao_tilgang.client.api.ApiResult
@@ -27,6 +29,7 @@ class NavBrukerServiceTest {
 	lateinit var rolleService: RolleService
 	lateinit var krrProxyClient: KrrProxyClient
 	lateinit var poaoTilgangClient: PoaoTilgangClient
+	lateinit var pdlClient: PdlClient
 
 	@BeforeEach
 	fun setup() {
@@ -36,6 +39,7 @@ class NavBrukerServiceTest {
 		navEnhetService = mockk()
 		krrProxyClient = mockk()
 		poaoTilgangClient = mockk()
+		pdlClient = mockk()
 		rolleService = mockk(relaxUnitFun = true)
 
 		service = NavBrukerService(
@@ -46,20 +50,24 @@ class NavBrukerServiceTest {
 			rolleService = rolleService,
 			krrProxyClient = krrProxyClient,
 			poaoTilgangClient = poaoTilgangClient,
+			pdlClient = pdlClient,
 		)
 	}
 
 	@Test
 	fun `hentEllerOpprettNavBruker - bruker finnes ikke - oppretter og returnerer ny bruker`() {
 		val person = TestData.lagPerson()
+		val personOpplysninger = TestData.lagPdlPerson(person = person)
+
 		val veileder =  TestData.lagNavAnsatt()
 		val navEnhet = TestData.lagNavEnhet()
 		val kontaktinformasjon = Kontaktinformasjon("navbruker@gmail.com", "99900111")
 		val erSkjermet = false
 
 		every { repository.get(person.personIdent) } returns null
-		every { personService.erAdressebeskyttet(person.personIdent) } returns false
-		every { personService.hentEllerOpprettPerson(person.personIdent) } returns person.toModel()
+		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
+		every { personService.erAdressebeskyttet(any()) } returns false
+		every { personService.hentEllerOpprettPerson(person.personIdent, personOpplysninger) } returns person.toModel()
 		every { navAnsattService.hentBrukersVeileder(person.personIdent) } returns veileder.toModel()
 		every { navEnhetService.hentNavEnhetForBruker(person.personIdent) } returns navEnhet.toModel()
 		every { krrProxyClient.hentKontaktinformasjon(person.personIdent) } returns kontaktinformasjon
@@ -79,9 +87,11 @@ class NavBrukerServiceTest {
 	@Test
 	fun `hentEllerOpprettNavBruker - bruker er adressebeskyttet - oppretter ikke bruker`() {
 		val person = TestData.lagPerson()
+		val personOpplysninger = TestData.lagPdlPerson(person, adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
 		every { repository.get(person.personIdent) } returns null
-		every { personService.erAdressebeskyttet(person.personIdent) } returns true
+		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
+		every { personService.erAdressebeskyttet(personOpplysninger.adressebeskyttelseGradering) } returns true
 
 		assertThrows<IllegalStateException> {
 			service.hentEllerOpprettNavBruker(person.personIdent)
@@ -96,23 +106,26 @@ class NavBrukerServiceTest {
 
 		service.oppdaterKontaktinformasjon(personer)
 
+		verify(exactly = 0) { pdlClient.hentTelefon(any()) }
 		verify(exactly = 0) { krrProxyClient.hentKontaktinformasjon(any()) }
 		verify(exactly = 0) { repository.oppdaterKontaktinformasjon(any(), any(), any()) }
 	}
 
 	@Test
-	fun `oppdaterKontaktInformasjon - bruker finnes - oppdaterer bruker`() {
+	fun `oppdaterKontaktInformasjon - telefon er registrert i krr og pdl - oppdaterer bruker med telefon fra krr`() {
 		val bruker = TestData.lagNavBruker()
 		val kontakinformasjon = Kontaktinformasjon(
 				"ny epost",
-				"nytt telefonnummer",
+				"krr-telefon",
 			)
 
 		every { repository.finnBrukerId(bruker.person.personIdent) } returns bruker.id
+		every { pdlClient.hentTelefon(bruker.person.personIdent) } returns "pdl-telefon"
 		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) } returns kontakinformasjon
 
 		service.oppdaterKontaktinformasjon(listOf(bruker.person.toModel()))
 
+		verify(exactly = 1) { pdlClient.hentTelefon(bruker.person.personIdent) }
 		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) }
 		verify(exactly = 1) { repository.oppdaterKontaktinformasjon(bruker.id, kontakinformasjon.telefonnummer, kontakinformasjon.epost) }
 	}

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
@@ -66,7 +66,6 @@ class NavBrukerServiceTest {
 
 		every { repository.get(person.personIdent) } returns null
 		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
-		every { personService.erAdressebeskyttet(any()) } returns false
 		every { personService.hentEllerOpprettPerson(person.personIdent, personOpplysninger) } returns person.toModel()
 		every { navAnsattService.hentBrukersVeileder(person.personIdent) } returns veileder.toModel()
 		every { navEnhetService.hentNavEnhetForBruker(person.personIdent) } returns navEnhet.toModel()
@@ -91,7 +90,6 @@ class NavBrukerServiceTest {
 
 		every { repository.get(person.personIdent) } returns null
 		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
-		every { personService.erAdressebeskyttet(personOpplysninger.adressebeskyttelseGradering) } returns true
 
 		assertThrows<IllegalStateException> {
 			service.hentEllerOpprettNavBruker(person.personIdent)

--- a/src/test/kotlin/no/nav/amt/person/service/person/model/AdressebeskyttelseGraderingTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/model/AdressebeskyttelseGraderingTest.kt
@@ -1,0 +1,26 @@
+package no.nav.amt.person.service.person.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AdressebeskyttelseGraderingTest {
+	@Test
+	fun `erBeskyttet - er null eller ugradert - skal returnere false`() {
+		val nullGradering: AdressebeskyttelseGradering? = null
+		val ugradert = AdressebeskyttelseGradering.UGRADERT
+
+		nullGradering.erBeskyttet() shouldBe false
+		ugradert.erBeskyttet() shouldBe false
+	}
+
+	@Test
+	fun `erBeskyttet - er ikke null eller ugradert - skal returnere true`() {
+		val fortrolig = AdressebeskyttelseGradering.FORTROLIG
+		val strengtFortrolig = AdressebeskyttelseGradering.STRENGT_FORTROLIG
+		val strengtFortroligUtland = AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
+
+		fortrolig.erBeskyttet() shouldBe true
+		strengtFortrolig.erBeskyttet() shouldBe true
+		strengtFortroligUtland.erBeskyttet() shouldBe true
+	}
+}


### PR DESCRIPTION
Siden man nå trenger flere personopplysninger fra pdl ved opprettelse av navbrukere, så gir det mer mening å trekke ut alle opplysningene med en gang i NavBrukerService. Og dermed bortfaller behovet for et eget kall for adressebeskyttelse.