### PR TITLE
Hent brukerid fra amt-tiltak ved opprettelse av arrangoransatt

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/controller/PersonController.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/PersonController.kt
@@ -9,9 +9,7 @@ import no.nav.amt.person.service.controller.request.NavEnhetRequest
 import no.nav.amt.person.service.nav_ansatt.NavAnsattService
 import no.nav.amt.person.service.nav_bruker.NavBrukerService
 import no.nav.amt.person.service.nav_enhet.NavEnhetService
-import no.nav.amt.person.service.person.PersonService
-import no.nav.amt.person.service.person.RolleService
-import no.nav.amt.person.service.person.model.Rolle
+import no.nav.amt.person.service.person.ArrangorAnsattService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.*
 
@@ -19,11 +17,10 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api")
 class PersonController (
-	private val personService: PersonService,
 	private val navAnsattService: NavAnsattService,
 	private val navBrukerService: NavBrukerService,
 	private val navEnhetService: NavEnhetService,
-	private val rolleService: RolleService,
+	private val arrangorAnsattService: ArrangorAnsattService,
 ) {
 
 	@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
@@ -47,8 +44,9 @@ class PersonController (
 	fun hentEllerOpprettArrangorAnsatt(
 		@RequestBody request: ArrangorAnsattRequest,
 	): ArrangorAnsattDto {
-		val person = personService.hentEllerOpprettPerson(request.personIdent)
-		rolleService.opprettRolle(person.id, Rolle.ARRANGOR_ANSATT)
+
+		val person = arrangorAnsattService.hentEllerOpprettAnsatt(request.personIdent)
+
 		return person.toArrangorAnsattDto()
 	}
 

--- a/src/main/kotlin/no/nav/amt/person/service/migrering/MigreringService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/migrering/MigreringService.kt
@@ -15,7 +15,7 @@ class MigreringService(
 
 	fun migrerNavBruker(migreringNavBruker: MigreringNavBruker) {
 		try {
-			personService.hentEllerOpprettPerson(migreringNavBruker.personIdent, migreringNavBruker.id)
+			personService.opprettPersonMedId(migreringNavBruker.personIdent, migreringNavBruker.id)
 			val bruker = navBrukerService.hentEllerOpprettNavBruker(migreringNavBruker.personIdent)
 			val diffMap = migreringNavBruker.diff(bruker)
 

--- a/src/main/kotlin/no/nav/amt/person/service/person/ArrangorAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/ArrangorAnsattService.kt
@@ -1,0 +1,30 @@
+package no.nav.amt.person.service.person
+
+import no.nav.amt.person.service.clients.amt_tiltak.AmtTiltakClient
+import no.nav.amt.person.service.person.model.Person
+import no.nav.amt.person.service.person.model.Rolle
+import org.springframework.stereotype.Service
+
+@Service
+class ArrangorAnsattService(
+	private val personService: PersonService,
+	private val rolleService: RolleService,
+	private val amtTiltakClient: AmtTiltakClient,
+) {
+	fun hentEllerOpprettAnsatt(personIdent: String): Person {
+		var person = personService.hentPerson(personIdent)
+
+		if (person == null) {
+			val brukerId = amtTiltakClient.hentBrukerId(personIdent)
+			person = if (brukerId != null) {
+				personService.opprettPersonMedId(personIdent, brukerId)
+			} else {
+				personService.hentEllerOpprettPerson(personIdent)
+			}
+		}
+
+		rolleService.opprettRolle(person.id, Rolle.ARRANGOR_ANSATT)
+
+		return person
+	}
+}

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
@@ -28,8 +28,12 @@ class PersonService(
 		return repository.get(personIdent)?.toModel()
 	}
 
-	fun hentEllerOpprettPerson(personIdent: String, nyPersonId: UUID = UUID.randomUUID()) : Person {
-		return repository.get(personIdent)?.toModel() ?: opprettPerson(personIdent, nyPersonId)
+	fun opprettPersonMedId(personIdent: String, nyPersonId: UUID) : Person {
+		return opprettPerson(personIdent, nyPersonId)
+	}
+
+	fun hentEllerOpprettPerson(personIdent: String) : Person {
+		return repository.get(personIdent)?.toModel() ?: opprettPerson(personIdent)
 	}
 
 	fun hentEllerOpprettPerson(personIdent: String, personOpplysninger: PdlPerson): Person {
@@ -71,7 +75,7 @@ class PersonService(
 		}
 	}
 
-	private fun opprettPerson(personIdent: String, nyPersonId: UUID): Person {
+	private fun opprettPerson(personIdent: String, nyPersonId: UUID = UUID.randomUUID()): Person {
 		val pdlPerson =	pdlClient.hentPerson(personIdent)
 
 		return opprettPerson(personIdent, pdlPerson, nyPersonId)

--- a/src/test/kotlin/no/nav/amt/person/service/clients/amt_tiltak/AmtTiltakClientTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/clients/amt_tiltak/AmtTiltakClientTest.kt
@@ -48,4 +48,27 @@ class AmtTiltakClientTest {
 		request.method shouldBe "GET"
 		request.getHeader("Authorization") shouldBe "Bearer TOKEN"
 	}
+
+	@Test
+	fun `hentBrukerId - bruker finnes - returnerer brukerId`() {
+		val brukerId = UUID.randomUUID()
+		val navEnhetId = UUID.randomUUID()
+
+		val response = MockResponse().setBody("""{
+				"brukerId": "$brukerId",
+				"navEnhetId": "$navEnhetId",
+				"personIdentType": "FOLKEREGISTERIDENT",
+				"historiskeIdenter": []
+			}""".trimMargin())
+
+		server.enqueue(response)
+
+		client.hentBrukerId("fnr")!! shouldBe brukerId
+
+		val request = server.takeRequest()
+
+		request.path shouldBe "/api/tiltaksarrangor/deltaker/bruker-info"
+		request.method shouldBe "POST"
+		request.getHeader("Authorization") shouldBe "Bearer TOKEN"
+	}
 }

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockAmtTiltakHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockAmtTiltakHttpServer.kt
@@ -3,7 +3,9 @@ package no.nav.amt.person.service.integration.mock.servers
 import no.nav.amt.person.service.clients.amt_tiltak.BrukerInfoDto
 import no.nav.amt.person.service.utils.JsonUtils
 import no.nav.amt.person.service.utils.MockHttpServer
+import no.nav.amt.person.service.utils.getBodyAsString
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
 import java.util.UUID
 
 class MockAmtTiltakHttpServer : MockHttpServer(name = "AmtTiltakHttpServer") {
@@ -15,4 +17,25 @@ class MockAmtTiltakHttpServer : MockHttpServer(name = "AmtTiltakHttpServer") {
 
 		addResponseHandler("/api/tiltaksarrangor/deltaker/$deltakerId/bruker-info", response)
 	}
+
+	fun mockHentBrukerId(personIdent: String, brukerInfo: BrukerInfoDto?) {
+		val response = if (brukerInfo == null) {
+			MockResponse()
+				.setResponseCode(404)
+		} else {
+			MockResponse()
+				.setResponseCode(200)
+				.setBody(JsonUtils.toJsonString(brukerInfo))
+		}
+
+
+		val requestPredicate = { req: RecordedRequest ->
+			req.path == "/api/tiltaksarrangor/deltaker/bruker-info"
+				&& req.method == "POST"
+				&& req.getBodyAsString() == """{"personident": "$personIdent"}"""
+		}
+
+		addResponseHandler(requestPredicate, response)
+	}
+
 }


### PR DESCRIPTION
For å bruke den som personId for arrangøransatte i tilfellet de også skal ha en navbruker som ikke er opprettet enda, underveis i migreringen av nav-brukere fra amt-tiltak til amt-person.