### PR TITLE
Lagre identer i egen tabell

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
@@ -25,7 +25,7 @@ class PersonRepository(
 			mellomnavn = rs.getString("mellomnavn"),
 			etternavn = rs.getString("etternavn"),
 			createdAt = rs.getTimestamp("created_at").toLocalDateTime(),
-			modifiedAt = rs.getTimestamp("modified_at").toLocalDateTime()
+			modifiedAt = rs.getTimestamp("modified_at").toLocalDateTime(),
 		)
 	}
 	fun get(id: UUID): PersonDbo {
@@ -105,11 +105,18 @@ class PersonRepository(
 	}
 
 	fun delete(id: UUID) {
+		val parameters = sqlParameters("id" to id)
+
+		val identSql = """
+			delete from personident where person_id = :id
+		""".trimIndent()
+
+		template.update(identSql, parameters)
+
 		val sql = """
 			delete from person where id = :id
 		""".trimIndent()
 
-		val parameters = sqlParameters("id" to id)
 
 		template.update(sql, parameters)
 	}

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonidentRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonidentRepository.kt
@@ -1,0 +1,78 @@
+package no.nav.amt.person.service.person
+
+import no.nav.amt.person.service.person.dbo.PersonidentDbo
+import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.person.model.Personident
+import no.nav.amt.person.service.utils.getUUID
+import no.nav.amt.person.service.utils.sqlParameters
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class PersonidentRepository(
+	val template: NamedParameterJdbcTemplate
+) {
+	private val rowMapper = RowMapper { rs, _ ->
+		PersonidentDbo(
+			ident = rs.getString("ident"),
+			personId = rs.getUUID("person_id"),
+			historisk = rs.getBoolean("historisk"),
+			type = rs.getString("type")?.let { IdentType.valueOf(it) } ?: IdentType.UKJENT,
+			createdAt = rs.getTimestamp("created_at").toLocalDateTime(),
+			modifiedAt = rs.getTimestamp("modified_at").toLocalDateTime(),
+		)
+
+	}
+
+	fun get(ident: String): PersonidentDbo? {
+		val sql = """
+			select * from personident where ident = :ident
+		""".trimIndent()
+
+		val parameters = sqlParameters("ident" to ident)
+
+		return template.query(sql, parameters, rowMapper).firstOrNull()
+	}
+
+	fun getAllForPerson(personId: UUID): List<PersonidentDbo> {
+		val sql = """
+			select * from personident where person_id = :personId
+		""".trimIndent()
+
+		val parameters = sqlParameters("personId" to personId)
+
+		return template.query(sql, parameters, rowMapper)
+	}
+
+	fun upsert(personId: UUID, identer: List<Personident>) {
+		val sql = """
+			insert into personident(
+				ident,
+				person_id,
+				type,
+				historisk
+			) values (
+				:ident,
+				:personId,
+				:type,
+				:historisk
+			) on conflict (ident, person_id) do update set
+				type = :type,
+				historisk = :historisk,
+				modified_at = current_timestamp
+		""".trimIndent()
+
+		val parameters = identer.map {
+			sqlParameters(
+				"ident" to it.ident,
+				"personId" to personId,
+				"historisk" to it.historisk,
+				"type" to it.type.name,
+			)
+		}
+		template.batchUpdate(sql, parameters.toTypedArray())
+	}
+
+}

--- a/src/main/kotlin/no/nav/amt/person/service/person/dbo/PersonidentDbo.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/dbo/PersonidentDbo.kt
@@ -1,0 +1,21 @@
+package no.nav.amt.person.service.person.dbo
+
+import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.person.model.Personident
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class PersonidentDbo(
+	val ident: String,
+	val personId: UUID,
+	val historisk: Boolean,
+	val type: IdentType,
+	val modifiedAt: LocalDateTime,
+	val createdAt: LocalDateTime,
+) {
+	fun toModel() = Personident(
+		this.ident,
+		this.historisk,
+		this.type
+	)
+}

--- a/src/main/kotlin/no/nav/amt/person/service/person/model/IdentType.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/model/IdentType.kt
@@ -1,5 +1,5 @@
 package no.nav.amt.person.service.person.model
 
 enum class IdentType{
-	FOLKEREGISTERIDENT, NPID, AKTORID,
+	FOLKEREGISTERIDENT, NPID, AKTORID, UKJENT,
 }

--- a/src/main/resources/db/migration/V08__personident-unique-id.sql
+++ b/src/main/resources/db/migration/V08__personident-unique-id.sql
@@ -1,0 +1,2 @@
+alter table personident
+    add constraint personident_ident_person_id_key unique (ident, person_id);

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -5,6 +5,7 @@ import no.nav.amt.person.service.nav_ansatt.NavAnsattDbo
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
 import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
+import no.nav.amt.person.service.person.dbo.PersonidentDbo
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
 import no.nav.amt.person.service.person.model.IdentType
 import no.nav.amt.person.service.person.model.Personident
@@ -100,7 +101,10 @@ object TestData {
 
 	fun lagPersonident(
 		ident: String = randomIdent(),
+		personId: UUID = UUID.randomUUID(),
 		historisk: Boolean = false,
 		type: IdentType = IdentType.FOLKEREGISTERIDENT,
-	) = Personident(ident, historisk, type)
+		modifiedAt: LocalDateTime = LocalDateTime.now(),
+		createdAt: LocalDateTime = LocalDateTime.now()
+	) = PersonidentDbo(ident, personId, historisk, type, modifiedAt, createdAt)
 }

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
@@ -4,13 +4,14 @@ import no.nav.amt.person.service.nav_ansatt.NavAnsattDbo
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
 import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
+import no.nav.amt.person.service.person.dbo.PersonidentDbo
 import no.nav.amt.person.service.person.model.Rolle
 import no.nav.amt.person.service.utils.sqlParameters
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
-import java.util.*
+import java.util.UUID
 
 @Component
 class TestDataRepository(
@@ -57,6 +58,36 @@ class TestDataRepository(
 				"modifiedAt" to person.modifiedAt,
 			)
 		)
+
+		insertPersonidenter(person.id, listOf(
+			TestData.lagPersonident(person.personIdent),
+		))
+	}
+
+	fun insertPersonidenter(personId: UUID, identer: List<PersonidentDbo>) {
+		val sql = """
+			insert into personident(
+				ident,
+				person_id,
+				type,
+				historisk
+			) values (
+				:ident,
+				:personId,
+				:type,
+				:historisk
+			)
+		""".trimIndent()
+
+		val parameters = identer.map {
+			sqlParameters(
+				"ident" to it.ident,
+				"personId" to personId,
+				"historisk" to it.historisk,
+				"type" to it.type.name,
+			)
+		}
+		template.batchUpdate(sql, parameters.toTypedArray())
 	}
 
 	fun insertNavEnhet(enhet: NavEnhetDbo) {

--- a/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
@@ -17,6 +17,7 @@ import no.nav.amt.person.service.nav_bruker.NavBrukerService
 import no.nav.amt.person.service.nav_enhet.NavEnhetService
 import no.nav.amt.person.service.person.PersonService
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
+import no.nav.amt.person.service.person.model.IdentType
 import okhttp3.Request
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -165,6 +166,11 @@ class PersonControllerTest: IntegrationTestBase() {
 		faktiskBruker.navEnhet!!.enhetId shouldBe body.navEnhet!!.enhetId
 		faktiskBruker.navEnhet!!.navn shouldBe body.navEnhet!!.navn
 		faktiskBruker.erSkjermet shouldBe body.erSkjermet
+
+		val ident = personService.hentIdenter(faktiskBruker.person.id).first()
+		ident.ident shouldBe body.personIdent
+		ident.type shouldBe IdentType.FOLKEREGISTERIDENT
+		ident.historisk shouldBe false
 	}
 
 	@Test

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
@@ -20,6 +20,7 @@ class PersonServiceTest {
 
 	lateinit var pdlClient: PdlClient
 	lateinit var repository: PersonRepository
+	lateinit var personidentRepository: PersonidentRepository
 	lateinit var service: PersonService
 	lateinit var applicationEventPublisher: ApplicationEventPublisher
 	lateinit var transactionTemplate: TransactionTemplate
@@ -28,11 +29,13 @@ class PersonServiceTest {
 	fun setup() {
 		pdlClient = mockk(relaxUnitFun = true)
 		repository = mockk(relaxUnitFun = true)
+		personidentRepository = mockk(relaxUnitFun = true)
 		applicationEventPublisher = mockk(relaxUnitFun = true)
 		transactionTemplate = mockk()
 		service = PersonService(
 			pdlClient = pdlClient,
 			repository = repository,
+			personidentRepository = personidentRepository,
 			applicationEventPublisher = applicationEventPublisher,
 			transactionTemplate = transactionTemplate
 		)

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonidentRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonidentRepositoryTest.kt
@@ -1,0 +1,65 @@
+package no.nav.amt.person.service.person
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.person.service.data.TestData
+import no.nav.amt.person.service.data.TestDataRepository
+import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.person.model.Personident
+import no.nav.amt.person.service.utils.DbTestDataUtils
+import no.nav.amt.person.service.utils.SingletonPostgresContainer
+import org.junit.AfterClass
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+
+class PersonidentRepositoryTest {
+
+	companion object {
+		private val dataSource = SingletonPostgresContainer.getDataSource()
+		private val jdbcTemplate = NamedParameterJdbcTemplate(dataSource)
+		val testRepository = TestDataRepository(jdbcTemplate)
+		val repository = PersonidentRepository(jdbcTemplate)
+
+		@JvmStatic
+		@AfterClass
+		fun tearDown() {
+			DbTestDataUtils.cleanDatabase(dataSource)
+		}
+	}
+
+
+	@Test
+	fun `upsertPersonident - nye identer - inserter`() {
+		val person = TestData.lagPerson()
+		testRepository.insertPerson(person)
+
+		val identer = listOf(
+			Personident(TestData.randomIdent(), true, IdentType.AKTORID),
+			Personident(TestData.randomIdent(), true, IdentType.NPID),
+		)
+
+		repository.upsert(person.id, identer)
+
+		val faktiskeIdenter = repository.getAllForPerson(person.id)
+
+		faktiskeIdenter.any { it.ident == identer[0].ident } shouldBe true
+		faktiskeIdenter.any { it.ident == identer[1].ident } shouldBe true
+	}
+
+	@Test
+	fun `upsertPersonident - ny ident - inserter og oppdaterer`() {
+		val person = TestData.lagPerson()
+		testRepository.insertPerson(person)
+
+		val identer = listOf(
+			TestData.lagPersonident(person.personIdent, historisk = true),
+			TestData.lagPersonident(TestData.randomIdent(), historisk = false),
+		)
+
+		repository.upsert(person.id, identer.map { it.toModel() })
+
+		val faktiskeIdenter = repository.getAllForPerson(person.id)
+
+		faktiskeIdenter.any { it.ident == identer[0].ident && it.historisk } shouldBe true
+		faktiskeIdenter.any { it.ident == identer[1].ident && !it.historisk } shouldBe true
+	}
+}

--- a/src/test/kotlin/no/nav/amt/person/service/person/model/PersonidentTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/model/PersonidentTest.kt
@@ -13,9 +13,9 @@ class PersonidentTest {
 			TestData.lagPersonident(historisk = true, type = IdentType.FOLKEREGISTERIDENT),
 			TestData.lagPersonident(historisk = false, type = IdentType.NPID),
 			TestData.lagPersonident(historisk = false, type = IdentType.AKTORID),
-		)
+		).map { it.toModel() }
 
-		finnGjeldendeIdent(identer).getOrThrow() shouldBe forventetIdent
+		finnGjeldendeIdent(identer).getOrThrow() shouldBe forventetIdent.toModel()
 	}
 
 	@Test
@@ -24,16 +24,16 @@ class PersonidentTest {
 		val identer = listOf(
 			TestData.lagPersonident(historisk = false, type = IdentType.AKTORID),
 			forventetIdent,
-		)
+		).map { it.toModel() }
 
-		finnGjeldendeIdent(identer).getOrThrow() shouldBe forventetIdent
+		finnGjeldendeIdent(identer).getOrThrow() shouldBe forventetIdent.toModel()
 	}
 
 	@Test
 	fun `finnGjeldendeIdent - kun aktorid - returner failure`() {
 		val identer = listOf(
 			TestData.lagPersonident(historisk = false, type = IdentType.AKTORID),
-		)
+		).map { it.toModel() }
 
 		finnGjeldendeIdent(identer).isFailure shouldBe true
 	}


### PR DESCRIPTION
Søk i historiske identer var alt for tregt når de kun var lagret som en array.

Beholder datamodellen som den er for å unngå å brekke noe før alle identer er lagret i ny tabell.