### PR TITLE
Fiks casing for personident variabler

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/clients/amt_tiltak/AmtTiltakClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/amt_tiltak/AmtTiltakClient.kt
@@ -34,11 +34,11 @@ class AmtTiltakClient(
 		}
 
 	}
-	fun hentBrukerId(personIdent: String): UUID? {
+	fun hentBrukerId(personident: String): UUID? {
 		val request = Request.Builder()
 			.url("$baseUrl/api/tiltaksarrangor/deltaker/bruker-info")
 			.header("Authorization", "Bearer ${tokenProvider.get()}")
-			.post("""{"personident": "$personIdent"}""".toRequestBody("application/json".toMediaType()))
+			.post("""{"personident": "$personident"}""".toRequestBody("application/json".toMediaType()))
 			.build()
 
 		httpClient.newCall(request).execute().use {response ->

--- a/src/main/kotlin/no/nav/amt/person/service/clients/krr/KrrProxyClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/krr/KrrProxyClient.kt
@@ -14,12 +14,12 @@ class KrrProxyClient(
 	private val httpClient: OkHttpClient = baseClient(),
 ) {
 
-	fun hentKontaktinformasjon(personIdent: String): Result<Kontaktinformasjon> {
+	fun hentKontaktinformasjon(personident: String): Result<Kontaktinformasjon> {
 		val request: Request = Request.Builder()
 			.url("$baseUrl/rest/v1/person?inkluderSikkerDigitalPost=false")
 			.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenProvider.get())
-			.header("Nav-Personident", personIdent)
+			.header("Nav-Personident", personident)
 			.build()
 
 		httpClient.newCall(request).execute().use { response ->

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
@@ -27,11 +27,11 @@ class PdlClient(
 
 	private val behandlingsnummer = "B446" // https://behandlingskatalog.nais.adeo.no/process/team/5345bce7-e076-4b37-8bf4-49030901a4c3/b3003849-c4bb-4c60-a4cb-e07ce6025623
 
-	fun hentPerson(personIdent: String): PdlPerson {
+	fun hentPerson(personident: String): PdlPerson {
 		val requestBody = toJsonString(
 			GraphqlUtils.GraphqlQuery(
 				PdlQueries.HentPerson.query,
-				PdlQueries.HentPerson.Variables(personIdent)
+				PdlQueries.HentPerson.Variables(personident)
 			)
 		)
 

--- a/src/main/kotlin/no/nav/amt/person/service/controller/PersonController.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/PersonController.kt
@@ -31,7 +31,7 @@ class PersonController (
 		@RequestBody request: NavBrukerRequest
 	): NavBrukerDto {
 		authService.verifyRequestIsMachineToMachine()
-		return navBrukerService.hentEllerOpprettNavBruker(request.personIdent).toDto()
+		return navBrukerService.hentEllerOpprettNavBruker(request.personident).toDto()
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
@@ -49,7 +49,9 @@ class PersonController (
 		@RequestBody request: ArrangorAnsattRequest,
 	): ArrangorAnsattDto {
 		authService.verifyRequestIsMachineToMachine()
-		val person = arrangorAnsattService.hentEllerOpprettAnsatt(request.personIdent)
+		val person = request.personident?.let {
+			arrangorAnsattService.hentEllerOpprettAnsatt(it)
+		} ?: arrangorAnsattService.hentEllerOpprettAnsatt(request.personIdent!!)
 
 		return person.toArrangorAnsattDto()
 	}

--- a/src/main/kotlin/no/nav/amt/person/service/controller/dto/ArrangorAnsattDto.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/dto/ArrangorAnsattDto.kt
@@ -1,11 +1,13 @@
 package no.nav.amt.person.service.controller.dto
 
 import no.nav.amt.person.service.person.model.Person
-import java.util.*
+import java.util.UUID
 
 data class ArrangorAnsattDto (
 	val id: UUID,
 	val personIdent: String,
+	// dobbelt opp for å være bakoverkompatibel til amt-arrangor er oppdatert
+	val personident: String,
 	val fornavn: String,
 	val mellomnavn: String?,
 	val etternavn: String,
@@ -13,7 +15,8 @@ data class ArrangorAnsattDto (
 
 fun Person.toArrangorAnsattDto() = ArrangorAnsattDto(
 	id = id,
-	personIdent = personIdent,
+	personIdent = personident,
+	personident = personident,
 	fornavn = fornavn,
 	mellomnavn = mellomnavn,
 	etternavn = etternavn,

--- a/src/main/kotlin/no/nav/amt/person/service/controller/dto/NavBrukerDto.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/dto/NavBrukerDto.kt
@@ -2,11 +2,11 @@ package no.nav.amt.person.service.controller.dto
 
 import no.nav.amt.person.service.nav_bruker.NavBruker
 import no.nav.amt.person.service.nav_enhet.NavEnhet
-import java.util.*
+import java.util.UUID
 
 data class NavBrukerDto (
 	val personId: UUID,
-	val personIdent: String,
+	val personident: String,
 	val fornavn: String,
 	val mellomnavn: String?,
 	val etternavn: String,
@@ -19,7 +19,7 @@ data class NavBrukerDto (
 
 fun NavBruker.toDto() = NavBrukerDto(
 	personId = this.person.id,
-	personIdent = this.person.personIdent,
+	personident = this.person.personident,
 	fornavn = this.person.fornavn,
 	mellomnavn = this.person.mellomnavn,
 	etternavn = this.person.etternavn,

--- a/src/main/kotlin/no/nav/amt/person/service/controller/request/ArrangorAnsattRequest.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/request/ArrangorAnsattRequest.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.person.service.controller.request
 
 data class ArrangorAnsattRequest(
-	val personIdent: String,
+	val personIdent: String?,
+	val personident: String?,
 )

--- a/src/main/kotlin/no/nav/amt/person/service/controller/request/NavBrukerRequest.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/request/NavBrukerRequest.kt
@@ -1,5 +1,5 @@
 package no.nav.amt.person.service.controller.request
 
 data class NavBrukerRequest(
-	val personIdent: String,
+	val personident: String,
 )

--- a/src/main/kotlin/no/nav/amt/person/service/internal/PersonUpdater.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/internal/PersonUpdater.kt
@@ -23,12 +23,12 @@ class PersonUpdater(
 			personer = personRepository.getAll(offset)
 
 			personer.forEach {
-				val identer = personService.hentIdenter(it.personIdent)
+				val identer = personService.hentIdenter(it.personident)
 
 				personService.oppdaterPersonIdent(identer)
 
 				finnGjeldendeIdent(identer).onSuccess { ident ->
-					if (ident.ident != it.personIdent) {
+					if (ident.ident != it.personident) {
 						log.info("Ny gjeldende ident for person ${it.id}")
 					}
 				}

--- a/src/main/kotlin/no/nav/amt/person/service/kafka/producer/KafkaProducerService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/producer/KafkaProducerService.kt
@@ -9,7 +9,7 @@ import no.nav.amt.person.service.utils.JsonUtils
 import no.nav.common.kafka.producer.KafkaProducerClient
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class KafkaProducerService(
@@ -24,7 +24,7 @@ class KafkaProducerService(
 
 		val navBrukerDto = NavBrukerDtoV1(
 			personId = navBruker.person.id,
-			personIdent = navBruker.person.personIdent,
+			personident = navBruker.person.personident,
 			fornavn = navBruker.person.fornavn,
 			mellomnavn = navBruker.person.mellomnavn,
 			etternavn = navBruker.person.etternavn,

--- a/src/main/kotlin/no/nav/amt/person/service/kafka/producer/dto/NavBrukerDtoV1.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/producer/dto/NavBrukerDtoV1.kt
@@ -1,10 +1,10 @@
 package no.nav.amt.person.service.kafka.producer.dto
 
-import java.util.*
+import java.util.UUID
 
 data class NavBrukerDtoV1 (
 	val personId: UUID,
-	val personIdent: String,
+	val personident: String,
 	val fornavn: String,
 	val mellomnavn: String?,
 	val etternavn: String,

--- a/src/main/kotlin/no/nav/amt/person/service/migrering/MigreringController.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/migrering/MigreringController.kt
@@ -219,8 +219,8 @@ data class MigreringNavBruker(
 
 		if (this.id != navBruker.person.id)
 			diffMap["personId"] = DiffProperty(this.id.toString(), navBruker.person.id.toString())
-		if (this.personIdent != navBruker.person.personIdent)
-			diffMap["personIdent"] = DiffProperty(this.personIdent, navBruker.person.personIdent)
+		if (this.personIdent != navBruker.person.personident)
+			diffMap["personIdent"] = DiffProperty(this.personIdent, navBruker.person.personident)
 		if (this.fornavn != navBruker.person.fornavn)
 			diffMap["fornavn"] = DiffProperty(this.fornavn, navBruker.person.fornavn)
 		if (this.mellomnavn != navBruker.person.mellomnavn)

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
@@ -23,7 +23,7 @@ class NavBrukerRepository(
 			id = rs.getUUID("nav_bruker.id"),
 			person = PersonDbo(
 				id = rs.getUUID("nav_bruker.person_id"),
-				personident = rs.getString("person.person_ident"),
+				personident = rs.getString("person.personident"),
 				fornavn = rs.getString("person.fornavn"),
 				mellomnavn = rs.getString("person.mellomnavn"),
 				etternavn = rs.getString("person.etternavn"),
@@ -128,7 +128,7 @@ class NavBrukerRepository(
 				   nav_bruker.er_skjermet as "nav_bruker.er_skjermet",
 				   nav_bruker.created_at as "nav_bruker.created_at",
 				   nav_bruker.modified_at as "nav_bruker.modified_at",
-				   person.person_ident as "person.person_ident",
+				   person.personident as "person.personident",
 				   person.fornavn as "person.fornavn",
 				   person.mellomnavn as "person.mellomnavn",
 				   person.etternavn as "person.etternavn",

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
@@ -23,7 +23,7 @@ class NavBrukerRepository(
 			id = rs.getUUID("nav_bruker.id"),
 			person = PersonDbo(
 				id = rs.getUUID("nav_bruker.person_id"),
-				personIdent = rs.getString("person.person_ident"),
+				personident = rs.getString("person.person_ident"),
 				fornavn = rs.getString("person.fornavn"),
 				mellomnavn = rs.getString("person.mellomnavn"),
 				etternavn = rs.getString("person.etternavn"),

--- a/src/main/kotlin/no/nav/amt/person/service/nav_enhet/NavEnhetService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_enhet/NavEnhetService.kt
@@ -4,7 +4,7 @@ import no.nav.amt.person.service.clients.norg.NorgClient
 import no.nav.amt.person.service.clients.veilarbarena.VeilarbarenaClient
 import no.nav.amt.person.service.config.SecureLog.secureLog
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class NavEnhetService(
@@ -13,13 +13,13 @@ class NavEnhetService(
 	private val veilarbarenaClient: VeilarbarenaClient
 ) {
 
-	fun hentNavEnhetForBruker(personIdent: String): NavEnhet? {
-		val oppfolgingsenhetId = veilarbarenaClient.hentBrukerOppfolgingsenhetId(personIdent) ?: return null
+	fun hentNavEnhetForBruker(personident: String): NavEnhet? {
+		val oppfolgingsenhetId = veilarbarenaClient.hentBrukerOppfolgingsenhetId(personident) ?: return null
 
 		return hentEllerOpprettNavEnhet(oppfolgingsenhetId)
 			.also {
 				if (it == null) {
-					secureLog.warn("Bruker med personIdent=$personIdent har enhetId=$oppfolgingsenhetId som ikke finnes i norg")
+					secureLog.warn("Bruker med personident=$personident har enhetId=$oppfolgingsenhetId som ikke finnes i norg")
 				}
 			}
 	}

--- a/src/main/kotlin/no/nav/amt/person/service/person/ArrangorAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/ArrangorAnsattService.kt
@@ -11,15 +11,15 @@ class ArrangorAnsattService(
 	private val rolleService: RolleService,
 	private val amtTiltakClient: AmtTiltakClient,
 ) {
-	fun hentEllerOpprettAnsatt(personIdent: String): Person {
-		var person = personService.hentPerson(personIdent)
+	fun hentEllerOpprettAnsatt(personident: String): Person {
+		var person = personService.hentPerson(personident)
 
 		if (person == null) {
-			val brukerId = amtTiltakClient.hentBrukerId(personIdent)
+			val brukerId = amtTiltakClient.hentBrukerId(personident)
 			person = if (brukerId != null) {
-				personService.opprettPersonMedId(personIdent, brukerId)
+				personService.opprettPersonMedId(personident, brukerId)
 			} else {
-				personService.hentEllerOpprettPerson(personIdent)
+				personService.hentEllerOpprettPerson(personident)
 			}
 		}
 

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
@@ -17,7 +17,7 @@ class PersonRepository(
 	private val rowMapper = RowMapper { rs, _ ->
 		PersonDbo(
 			id = rs.getUUID("id"),
-			personident = rs.getString("person_ident"),
+			personident = rs.getString("personident"),
 			fornavn = rs.getString("fornavn"),
 			mellomnavn = rs.getString("mellomnavn"),
 			etternavn = rs.getString("etternavn"),
@@ -46,7 +46,7 @@ class PersonRepository(
 		val sql = """
 			insert into person(
 				id,
-				person_ident,
+				personident,
 				fornavn,
 				mellomnavn,
 				etternavn
@@ -60,7 +60,7 @@ class PersonRepository(
 				fornavn = :fornavn,
 				mellomnavn = :mellomnavn,
 				etternavn = :etternavn,
-				person_ident = :personident,
+				personident = :personident,
 				modified_at = current_timestamp
 		""".trimIndent()
 

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonRepository.kt
@@ -17,7 +17,7 @@ class PersonRepository(
 	private val rowMapper = RowMapper { rs, _ ->
 		PersonDbo(
 			id = rs.getUUID("id"),
-			personIdent = rs.getString("person_ident"),
+			personident = rs.getString("person_ident"),
 			fornavn = rs.getString("fornavn"),
 			mellomnavn = rs.getString("mellomnavn"),
 			etternavn = rs.getString("etternavn"),
@@ -66,7 +66,7 @@ class PersonRepository(
 
 		val parameters = sqlParameters(
 			"id" to person.id,
-			"personident" to person.personIdent,
+			"personident" to person.personident,
 			"fornavn" to person.fornavn.titlecase(),
 			"mellomnavn" to person.mellomnavn?.titlecase(),
 			"etternavn" to person.etternavn.titlecase(),

--- a/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/PersonService.kt
@@ -27,32 +27,32 @@ fun hentPerson(id: UUID): Person {
 		return repository.get(id).toModel()
 	}
 
-	fun hentPerson(personIdent: String): Person? {
-		return repository.get(personIdent)?.toModel()
+	fun hentPerson(personident: String): Person? {
+		return repository.get(personident)?.toModel()
 	}
 
-	fun opprettPersonMedId(personIdent: String, nyPersonId: UUID) : Person {
-		return opprettPerson(personIdent, nyPersonId)
+	fun opprettPersonMedId(personident: String, nyPersonId: UUID) : Person {
+		return opprettPerson(personident, nyPersonId)
 	}
 
 	@Retryable(maxAttempts = 2)
-	fun hentEllerOpprettPerson(personIdent: String) : Person {
-		return repository.get(personIdent)?.toModel() ?: opprettPerson(personIdent)
+	fun hentEllerOpprettPerson(personident: String) : Person {
+		return repository.get(personident)?.toModel() ?: opprettPerson(personident)
 	}
 
-	fun hentEllerOpprettPerson(personIdent: String, personOpplysninger: PdlPerson): Person {
-		return repository.get(personIdent)?.toModel() ?: opprettPerson(personOpplysninger)
+	fun hentEllerOpprettPerson(personident: String, personOpplysninger: PdlPerson): Person {
+		return repository.get(personident)?.toModel() ?: opprettPerson(personOpplysninger)
 	}
 
-	fun hentPersoner(personIdenter: List<String>): List<Person> {
-		return repository.getPersoner(personIdenter).map { it.toModel() }
+	fun hentPersoner(personidenter: List<String>): List<Person> {
+		return repository.getPersoner(personidenter).map { it.toModel() }
 	}
 
 	fun hentIdenter(personId: UUID) = personidentRepository.getAllForPerson(personId).map { it.toModel() }
 
-	fun hentIdenter(personIdent: String) = pdlClient.hentIdenter(personIdent)
+	fun hentIdenter(personident: String) = pdlClient.hentIdenter(personident)
 
-	fun hentGjeldendeIdent(personIdent: String) = finnGjeldendeIdent(pdlClient.hentIdenter(personIdent)).getOrThrow()
+	fun hentGjeldendeIdent(personident: String) = finnGjeldendeIdent(pdlClient.hentIdenter(personident)).getOrThrow()
 
 	fun oppdaterPersonIdent(identer: List<Personident>) {
 		val personer = repository.getPersoner(identer.map { it.ident })
@@ -66,7 +66,7 @@ fun hentPerson(id: UUID): Person {
 
 		personer.firstOrNull()?.let { person ->
 			upsert(person.copy(
-				personIdent = gjeldendeIdent.ident,
+				personident = gjeldendeIdent.ident,
 			).toModel())
 			personidentRepository.upsert(person.id, identer)
 		}
@@ -82,8 +82,8 @@ fun hentPerson(id: UUID): Person {
 		}
 	}
 
-	private fun opprettPerson(personIdent: String, nyPersonId: UUID = UUID.randomUUID()): Person {
-		val pdlPerson =	pdlClient.hentPerson(personIdent)
+	private fun opprettPerson(personident: String, nyPersonId: UUID = UUID.randomUUID()): Person {
+		val pdlPerson =	pdlClient.hentPerson(personident)
 
 		return opprettPerson(pdlPerson, nyPersonId)
 	}
@@ -93,7 +93,7 @@ fun hentPerson(id: UUID): Person {
 
 		val person = Person(
 			id = nyPersonId,
-			personIdent = gjeldendeIdent.ident,
+			personident = gjeldendeIdent.ident,
 			fornavn = pdlPerson.fornavn,
 			mellomnavn = pdlPerson.mellomnavn,
 			etternavn = pdlPerson.etternavn,
@@ -110,7 +110,7 @@ fun hentPerson(id: UUID): Person {
 	fun slettPerson(person: Person) {
 		repository.delete(person.id)
 
-		secureLog.info("Slettet person med ident: ${person.personIdent}")
+		secureLog.info("Slettet person med ident: ${person.personident}")
 		log.info("Slettet person med id: ${person.id}")
 	}
 

--- a/src/main/kotlin/no/nav/amt/person/service/person/dbo/PersonDbo.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/dbo/PersonDbo.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 data class PersonDbo(
 	val id: UUID,
-	val personIdent: String,
+	val personident: String,
 	val fornavn: String,
 	val mellomnavn: String?,
 	val etternavn: String,
@@ -16,7 +16,7 @@ data class PersonDbo(
 	fun toModel(): Person {
 		return Person(
 			id,
-			personIdent,
+			personident,
 			fornavn,
 			mellomnavn,
 			etternavn,

--- a/src/main/kotlin/no/nav/amt/person/service/person/model/Person.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/model/Person.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class Person(
 	val id: UUID,
-	val personIdent: String,
+	val personident: String,
 	val fornavn: String,
 	val mellomnavn: String?,
 	val etternavn: String,

--- a/src/main/resources/db/migration/V10__personident-casing.sql
+++ b/src/main/resources/db/migration/V10__personident-casing.sql
@@ -1,0 +1,2 @@
+alter table person rename column person_ident to personident;
+

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -26,7 +26,7 @@ object TestData {
 
 	fun lagPerson(
 		id: UUID = UUID.randomUUID(),
-		personIdent: String = randomIdent(),
+		personident: String = randomIdent(),
 		fornavn: String = "Fornavn",
 		mellomnavn: String? = null,
 		etternavn: String = "Etternavn",
@@ -34,7 +34,7 @@ object TestData {
 		modifiedAt: LocalDateTime = LocalDateTime.now(),
 	) = PersonDbo(
 			id,
-			personIdent,
+			personident,
 			fornavn,
 			mellomnavn,
 			etternavn,
@@ -82,10 +82,10 @@ object TestData {
 	) = NavBrukerDbo(id, person, navVeileder, navEnhet, telefon, epost, erSkjermet, createdAt, modifiedAt)
 
 	fun lagPdlPerson(
-		person: PersonDbo,
-		telefon: String? = null,
-		adressebeskyttelseGradering: AdressebeskyttelseGradering? = null,
-		identer: List<Personident> = listOf(Personident(person.personIdent, false, IdentType.FOLKEREGISTERIDENT)),
+        person: PersonDbo,
+        telefon: String? = null,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering? = null,
+        identer: List<Personident> = listOf(Personident(person.personident, false, IdentType.FOLKEREGISTERIDENT)),
 	) = PdlPerson(
 		fornavn = person.fornavn,
 		mellomnavn = person.mellomnavn,

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
@@ -24,7 +24,7 @@ class TestDataRepository(
 		val sql = """
 			insert into person(
 				id,
-				person_ident,
+				personident,
 				fornavn,
 				mellomnavn,
 				etternavn,

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestDataRepository.kt
@@ -32,7 +32,7 @@ class TestDataRepository(
 				modified_at
 			) values (
 				:id,
-				:personIdent,
+				:personident,
 				:fornavn,
 				:mellomnavn,
 				:etternavn,
@@ -44,7 +44,7 @@ class TestDataRepository(
 		template.update(
 			sql, sqlParameters(
 				"id" to person.id,
-				"personIdent" to person.personIdent,
+				"personident" to person.personident,
 				"fornavn" to person.fornavn,
 				"mellomnavn" to person.mellomnavn,
 				"etternavn" to person.etternavn,
@@ -54,7 +54,7 @@ class TestDataRepository(
 		)
 
 		insertPersonidenter(
-			listOf(TestData.lagPersonident(person.personIdent, person.id))
+			listOf(TestData.lagPersonident(person.personident, person.id))
 		)
 	}
 

--- a/src/test/kotlin/no/nav/amt/person/service/data/kafka/KafkaMessageCreator.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/kafka/KafkaMessageCreator.kt
@@ -11,7 +11,7 @@ import no.nav.person.pdl.leesah.adressebeskyttelse.Gradering
 import no.nav.person.pdl.leesah.navn.Navn
 import java.time.LocalDate
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 object KafkaMessageCreator {
 	fun lagEndringPaaBrukerMsg(
@@ -33,22 +33,22 @@ object KafkaMessageCreator {
 	)
 
 	fun lagPersonhendelseAdressebeskyttelse(
-		personIdenter: List<String>,
+		personidenter: List<String>,
 		gradering: Gradering,
 	) = lagPersonhendelse(
-		personIdenter = personIdenter,
+		personidenter = personidenter,
 		navn = null,
 		adressebeskyttelse = Adressebeskyttelse(gradering),
 		opplysningsType = OpplysningsType.ADRESSEBESKYTTELSE_V1,
 	)
 
 	fun lagPersonhendelseNavn(
-		personIdenter: List<String>,
-		fornavn: String,
-		mellomnavn: String?,
-		etternavn: String,
+        personidenter: List<String>,
+        fornavn: String,
+        mellomnavn: String?,
+        etternavn: String,
 	) = lagPersonhendelse(
-		personIdenter = personIdenter,
+		personidenter = personidenter,
 		navn = Navn(
 			/* fornavn = */ fornavn,
 			/* mellomnavn = */ mellomnavn,
@@ -62,13 +62,13 @@ object KafkaMessageCreator {
 	)
 
 	private fun lagPersonhendelse(
-		personIdenter: List<String>,
+		personidenter: List<String>,
 		navn: Navn?,
 		adressebeskyttelse: Adressebeskyttelse?,
 		opplysningsType: OpplysningsType
 	) = Personhendelse(
 			/* hendelseId = */ UUID.randomUUID().toString(),
-			/* personidenter = */ personIdenter,
+			/* personidenter = */ personidenter,
 			/* master = */ "FREG",
 			/* opprettet = */ ZonedDateTime.now().toInstant(),
 			/* opplysningstype = */ opplysningsType.toString(),

--- a/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/controller/PersonControllerTest.kt
@@ -44,23 +44,23 @@ class PersonControllerTest: IntegrationTestBase() {
 		val person = TestData.lagPerson()
 		val token = mockOAuthServer.issueAzureAdM2MToken()
 
-		mockAmtTiltakHttpServer.mockHentBrukerId(person.personIdent, null)
+		mockAmtTiltakHttpServer.mockHentBrukerId(person.personident, null)
 		mockPdlHttpServer.mockHentPerson(person)
 
 		val response = sendRequest(
 			method = "POST",
 			path = "/api/arrangor-ansatt",
-			body = """{"personIdent": "${person.personIdent}"}""".toJsonRequestBody(),
+			body = """{"personident": "${person.personident}"}""".toJsonRequestBody(),
 			headers = mapOf("Authorization" to "Bearer $token")
 		)
 
 		response.code shouldBe 200
 
 		val body = objectMapper.readValue<ArrangorAnsattDto>(response.body!!.string())
-		val faktiskPerson = personService.hentPerson(person.personIdent)!!
+		val faktiskPerson = personService.hentPerson(person.personident)!!
 
 		faktiskPerson.id shouldBe body.id
-		faktiskPerson.personIdent shouldBe body.personIdent
+		faktiskPerson.personident shouldBe body.personident
 		faktiskPerson.fornavn shouldBe body.fornavn
 		faktiskPerson.mellomnavn shouldBe body.mellomnavn
 		faktiskPerson.etternavn shouldBe body.etternavn
@@ -71,7 +71,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		val person = TestData.lagPerson()
 		val brukerId = UUID.randomUUID()
 
-		mockAmtTiltakHttpServer.mockHentBrukerId(person.personIdent, BrukerInfoDto(
+		mockAmtTiltakHttpServer.mockHentBrukerId(person.personident, BrukerInfoDto(
 			brukerId,
 			UUID.randomUUID(),
 			IdentType.FOLKEREGISTERIDENT,
@@ -84,17 +84,17 @@ class PersonControllerTest: IntegrationTestBase() {
 		val response = sendRequest(
 			method = "POST",
 			path = "/api/arrangor-ansatt",
-			body = """{"personIdent": "${person.personIdent}"}""".toJsonRequestBody(),
+			body = """{"personident": "${person.personident}"}""".toJsonRequestBody(),
 			headers = mapOf("Authorization" to "Bearer $token")
 		)
 
 		response.code shouldBe 200
 
 		val body = objectMapper.readValue<ArrangorAnsattDto>(response.body!!.string())
-		val faktiskPerson = personService.hentPerson(person.personIdent)!!
+		val faktiskPerson = personService.hentPerson(person.personident)!!
 
 		faktiskPerson.id shouldBe brukerId
-		faktiskPerson.personIdent shouldBe body.personIdent
+		faktiskPerson.personident shouldBe body.personident
 		faktiskPerson.fornavn shouldBe body.fornavn
 		faktiskPerson.mellomnavn shouldBe body.mellomnavn
 		faktiskPerson.etternavn shouldBe body.etternavn
@@ -111,17 +111,17 @@ class PersonControllerTest: IntegrationTestBase() {
 		val response = sendRequest(
 			method = "POST",
 			path = "/api/arrangor-ansatt",
-			body = """{"personIdent": "${person.personIdent}"}""".toJsonRequestBody(),
+			body = """{"personident": "${person.personident}"}""".toJsonRequestBody(),
 			headers = mapOf("Authorization" to "Bearer $token")
 		)
 
 		response.code shouldBe 200
 
 		val body = objectMapper.readValue<ArrangorAnsattDto>(response.body!!.string())
-		val faktiskPerson = personService.hentPerson(person.personIdent)!!
+		val faktiskPerson = personService.hentPerson(person.personident)!!
 
 		faktiskPerson.id shouldBe body.id
-		faktiskPerson.personIdent shouldBe body.personIdent
+		faktiskPerson.personident shouldBe body.personident
 		faktiskPerson.fornavn shouldBe body.fornavn
 		faktiskPerson.mellomnavn shouldBe body.mellomnavn
 		faktiskPerson.etternavn shouldBe body.etternavn
@@ -135,27 +135,27 @@ class PersonControllerTest: IntegrationTestBase() {
 		val navBruker = TestData.lagNavBruker(navVeileder = navAnsatt, navEnhet = navEnhet)
 
 		mockPdlHttpServer.mockHentPerson(navBruker.person)
-		mockVeilarboppfolgingHttpServer.mockHentVeilederIdent(navBruker.person.personIdent, navAnsatt.navIdent)
-		mockVeilarbarenaHttpServer.mockHentBrukerOppfolgingsenhetId(navBruker.person.personIdent, navEnhet.enhetId)
+		mockVeilarboppfolgingHttpServer.mockHentVeilederIdent(navBruker.person.personident, navAnsatt.navIdent)
+		mockVeilarbarenaHttpServer.mockHentBrukerOppfolgingsenhetId(navBruker.person.personident, navEnhet.enhetId)
 		mockKrrProxyHttpServer.mockHentKontaktinformasjon(MockKontaktinformasjon(navBruker.epost, navBruker.telefon))
-		mockPoaoTilgangHttpServer.addErSkjermetResponse(mapOf(navBruker.person.personIdent to false))
+		mockPoaoTilgangHttpServer.addErSkjermetResponse(mapOf(navBruker.person.personident to false))
 		mockNomHttpServer.mockHentNavAnsatt(navAnsatt.toModel())
 		mockNorgHttpServer.mockHentNavEnhet(navEnhet.toModel())
 
 		val response = sendRequest(
 			method = "POST",
 			path = "/api/nav-bruker",
-			body = """{"personIdent": "${navBruker.person.personIdent}"}""".toJsonRequestBody(),
+			body = """{"personident": "${navBruker.person.personident}"}""".toJsonRequestBody(),
 			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueAzureAdM2MToken()}")
 		)
 
 		response.code shouldBe 200
 
 		val body = objectMapper.readValue<NavBrukerDto>(response.body!!.string())
-		val faktiskBruker = navBrukerService.hentNavBruker(navBruker.person.personIdent)!!
+		val faktiskBruker = navBrukerService.hentNavBruker(navBruker.person.personident)!!
 
 		faktiskBruker.person.id shouldBe body.personId
-		faktiskBruker.person.personIdent shouldBe body.personIdent
+		faktiskBruker.person.personident shouldBe body.personident
 		faktiskBruker.person.fornavn shouldBe body.fornavn
 		faktiskBruker.person.mellomnavn shouldBe body.mellomnavn
 		faktiskBruker.person.etternavn shouldBe body.etternavn
@@ -168,7 +168,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		faktiskBruker.erSkjermet shouldBe body.erSkjermet
 
 		val ident = personService.hentIdenter(faktiskBruker.person.id).first()
-		ident.ident shouldBe body.personIdent
+		ident.ident shouldBe body.personident
 		ident.type shouldBe IdentType.FOLKEREGISTERIDENT
 		ident.historisk shouldBe false
 	}
@@ -178,7 +178,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		val navBruker = TestData.lagNavBruker()
 
 		mockPdlHttpServer.mockHentPerson(
-			navBruker.person.personIdent,
+			navBruker.person.personident,
 			TestData.lagPdlPerson(
 				person = navBruker.person,
 				adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG
@@ -188,7 +188,7 @@ class PersonControllerTest: IntegrationTestBase() {
 		val response = sendRequest(
 			method = "POST",
 			path = "/api/nav-bruker",
-			body = """{"personIdent": "${navBruker.person.personIdent}"}""".toJsonRequestBody(),
+			body = """{"personident": "${navBruker.person.personident}"}""".toJsonRequestBody(),
 			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueAzureAdM2MToken()}")
 		)
 

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/AktorV2IngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/AktorV2IngestorTest.kt
@@ -32,7 +32,7 @@ class AktorV2IngestorTest : IntegrationTestBase() {
 		val msg = Aktor(
 			listOf(
 				Identifikator(nyttFnr, Type.FOLKEREGISTERIDENT, true),
-				Identifikator(person.personIdent, Type.FOLKEREGISTERIDENT, false),
+				Identifikator(person.personident, Type.FOLKEREGISTERIDENT, false),
 			)
 		)
 
@@ -45,7 +45,7 @@ class AktorV2IngestorTest : IntegrationTestBase() {
 
 			val identer = personService.hentIdenter(faktiskPerson!!.id)
 
-			identer.find { it.ident == person.personIdent }!!.let {
+			identer.find { it.ident == person.personident }!!.let {
 				it.historisk shouldBe true
 				it.type shouldBe IdentType.FOLKEREGISTERIDENT
 			}
@@ -65,7 +65,7 @@ class AktorV2IngestorTest : IntegrationTestBase() {
 			listOf(
 				Identifikator(aktorId, Type.AKTORID, true),
 				Identifikator(nyttFnr, Type.FOLKEREGISTERIDENT, true),
-				Identifikator(person.personIdent, Type.FOLKEREGISTERIDENT, false),
+				Identifikator(person.personident, Type.FOLKEREGISTERIDENT, false),
 			)
 		)
 
@@ -76,13 +76,13 @@ class AktorV2IngestorTest : IntegrationTestBase() {
 		AsyncUtils.eventually {
 			val faktiskPerson = personService.hentPerson(nyttFnr)
 
-			faktiskPerson!!.personIdent shouldBe nyttFnr
+			faktiskPerson!!.personident shouldBe nyttFnr
 
 			val identer = personService.hentIdenter(faktiskPerson.id)
 
 			identer shouldHaveSize 3
 
-			identer.find { it.ident == person.personIdent }!!.historisk shouldBe true
+			identer.find { it.ident == person.personident }!!.historisk shouldBe true
 		}
 
 	}

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/DeltakerV2IngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/DeltakerV2IngestorTest.kt
@@ -40,7 +40,7 @@ class DeltakerV2IngestorTest : IntegrationTestBase() {
 		val msg = DeltakerDto(
 			id = deltakerId,
 			personalia = DeltakerDto.DeltakerPersonaliaDto(
-				navBruker.person.personIdent,
+				navBruker.person.personident,
 				DeltakerDto.DeltakerPersonaliaDto.NavnDto(
 					navBruker.person.fornavn,
 					navBruker.person.mellomnavn,
@@ -68,14 +68,14 @@ class DeltakerV2IngestorTest : IntegrationTestBase() {
 
 		mockPdlHttpServer.mockHentPerson(navBruker.person)
 		mockKrrProxyHttpServer.mockHentKontaktinformasjon(kontaktinfoDiff)
-		mockPoaoTilgangHttpServer.addErSkjermetResponse(mapOf(navBruker.person.personIdent to navBruker.erSkjermet))
-		mockVeilarboppfolgingHttpServer.mockHentVeilederIdent(navBruker.person.personIdent, navBruker.navVeileder!!.navIdent)
-		mockVeilarbarenaHttpServer.mockHentBrukerOppfolgingsenhetId(navBruker.person.personIdent, navBruker.navEnhet!!.enhetId)
+		mockPoaoTilgangHttpServer.addErSkjermetResponse(mapOf(navBruker.person.personident to navBruker.erSkjermet))
+		mockVeilarboppfolgingHttpServer.mockHentVeilederIdent(navBruker.person.personident, navBruker.navVeileder!!.navIdent)
+		mockVeilarbarenaHttpServer.mockHentBrukerOppfolgingsenhetId(navBruker.person.personident, navBruker.navEnhet!!.enhetId)
 
 		kafkaMessageSender.sendTilDeltakerV2Topic(deltakerId, JsonUtils.toJsonString(msg))
 
 		AsyncUtils.eventually {
-			val faktiskBruker = navBrukerService.hentNavBruker(navBruker.person.personIdent)
+			val faktiskBruker = navBrukerService.hentNavBruker(navBruker.person.personident)
 			faktiskBruker shouldNotBe null
 
 			faktiskBruker!!.navEnhet?.id shouldBe navBruker.navEnhet?.id

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/EndringPaaBrukerIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/EndringPaaBrukerIngestorTest.kt
@@ -2,8 +2,8 @@ package no.nav.amt.person.service.integration.kafka.ingestor
 
 import io.kotest.matchers.shouldBe
 import no.nav.amt.person.service.data.TestData
-import no.nav.amt.person.service.integration.IntegrationTestBase
 import no.nav.amt.person.service.data.kafka.KafkaMessageCreator
+import no.nav.amt.person.service.integration.IntegrationTestBase
 import no.nav.amt.person.service.integration.kafka.utils.KafkaMessageSender
 import no.nav.amt.person.service.nav_bruker.NavBrukerService
 import no.nav.amt.person.service.utils.AsyncUtils
@@ -24,7 +24,7 @@ class EndringPaaBrukerIngestorTest : IntegrationTestBase() {
 		val navBruker = TestData.lagNavBruker(navEnhet = null)
 
 		val msg = KafkaMessageCreator.lagEndringPaaBrukerMsg(
-			fodselsnummer = navBruker.person.personIdent,
+			fodselsnummer = navBruker.person.personident,
 			oppfolgingsenhet = navEnhet.enhetId,
 		)
 

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
@@ -42,10 +42,10 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		val nyTelefon = "+12345678"
 
 		mockKrrProxyHttpServer.mockHentKontaktinformasjon(MockKontaktinformasjon(nyEpost, nyTelefon))
-		mockPdlHttpServer.mockHentTelefon(person.personIdent, null)
+		mockPdlHttpServer.mockHentTelefon(person.personident, null)
 
 		val msg = KafkaMessageCreator.lagPersonhendelseNavn(
-			personIdenter = listOf(person.personIdent),
+			personidenter = listOf(person.personident),
 			fornavn = nyttFornavn,
 			mellomnavn = nyttMellomnavn,
 			etternavn = nyttEtternavn,
@@ -74,7 +74,7 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		testDataRepository.insertNavBruker(navBruker)
 
 		val msg = KafkaMessageCreator.lagPersonhendelseAdressebeskyttelse(
-			personIdenter = listOf(navBruker.person.personIdent),
+			personidenter = listOf(navBruker.person.personident),
 			gradering = Gradering.STRENGT_FORTROLIG,
 		)
 
@@ -83,8 +83,8 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		kafkaMessageSender.sendTilLeesahTopic("aktorId", msg, 1)
 
 		AsyncUtils.eventually {
-			navBrukerService.hentNavBruker(navBruker.person.personIdent) shouldBe null
-			personService.hentPerson(navBruker.person.personIdent) shouldBe null
+			navBrukerService.hentNavBruker(navBruker.person.personident) shouldBe null
+			personService.hentPerson(navBruker.person.personident) shouldBe null
 		}
 
 	}
@@ -96,7 +96,7 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		testDataRepository.insertRolle(navBruker.person.id, Rolle.ARRANGOR_ANSATT)
 
 		val msg = KafkaMessageCreator.lagPersonhendelseAdressebeskyttelse(
-			personIdenter = listOf(navBruker.person.personIdent),
+			personidenter = listOf(navBruker.person.personident),
 			gradering = Gradering.STRENGT_FORTROLIG,
 		)
 
@@ -105,8 +105,8 @@ class LeesahIngestorTest : IntegrationTestBase() {
 		kafkaMessageSender.sendTilLeesahTopic("aktorId", msg, 1)
 
 		AsyncUtils.eventually {
-			navBrukerService.hentNavBruker(navBruker.person.personIdent) shouldBe null
-			personService.hentPerson(navBruker.person.personIdent) shouldNotBe null
+			navBrukerService.hentNavBruker(navBruker.person.personident) shouldBe null
+			personService.hentPerson(navBruker.person.personident) shouldNotBe null
 		}
 
 	}

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/SkjermetPersonIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/SkjermetPersonIngestorTest.kt
@@ -22,7 +22,7 @@ class SkjermetPersonIngestorTest: IntegrationTestBase() {
 		val bruker = TestData.lagNavBruker(erSkjermet = false)
 		testDataRepository.insertNavBruker(bruker)
 
-		kafkaMessageSender.sendTilSkjermetPersonTopic(bruker.person.personIdent, true)
+		kafkaMessageSender.sendTilSkjermetPersonTopic(bruker.person.personident, true)
 
 		AsyncUtils.eventually {
 			val faktiskBruker = navBrukerService.hentNavBruker(bruker.id)

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/TildeltVeilederIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/TildeltVeilederIngestorTest.kt
@@ -34,7 +34,7 @@ class TildeltVeilederIngestorTest : IntegrationTestBase() {
 		val navAnsatt = TestData.lagNavAnsatt(navIdent = msg.veilederId)
 
 
-		mockPdlHttpServer.mockHentIdenter(msg.aktorId, navBruker.person.personIdent)
+		mockPdlHttpServer.mockHentIdenter(msg.aktorId, navBruker.person.personident)
 		mockNomHttpServer.mockHentNavAnsatt(navAnsatt.toModel())
 
 		kafkaMessageSender.sendTilTildeltVeilederTopic(msg.toJson())

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavBrukerProducerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavBrukerProducerTest.kt
@@ -86,7 +86,7 @@ class NavBrukerProducerTest: IntegrationTestBase() {
 		return JsonUtils.toJsonString(
 			NavBrukerDtoV1(
 				personId = navBruker.person.id,
-				personIdent = navBruker.person.personIdent,
+				personident = navBruker.person.personident,
 				fornavn = navBruker.person.fornavn,
 				mellomnavn = navBruker.person.mellomnavn,
 				etternavn = navBruker.person.etternavn,

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/utils/KafkaMessageSender.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/utils/KafkaMessageSender.kt
@@ -65,11 +65,11 @@ class KafkaMessageSender(
 		)
 	}
 
-	fun sendTilSkjermetPersonTopic(personIdent: String, erSkjermet: Boolean) {
+	fun sendTilSkjermetPersonTopic(personident: String, erSkjermet: Boolean) {
 		kafkaProducer.send(
 			ProducerRecord(
 				skjermedePersonerTopic,
-				personIdent,
+				personident,
 				erSkjermet.toString(),
 			)
 		)

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockAmtTiltakHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockAmtTiltakHttpServer.kt
@@ -18,7 +18,7 @@ class MockAmtTiltakHttpServer : MockHttpServer(name = "AmtTiltakHttpServer") {
 		addResponseHandler("/api/tiltaksarrangor/deltaker/$deltakerId/bruker-info", response)
 	}
 
-	fun mockHentBrukerId(personIdent: String, brukerInfo: BrukerInfoDto?) {
+	fun mockHentBrukerId(personident: String, brukerInfo: BrukerInfoDto?) {
 		val response = if (brukerInfo == null) {
 			MockResponse()
 				.setResponseCode(404)
@@ -32,7 +32,7 @@ class MockAmtTiltakHttpServer : MockHttpServer(name = "AmtTiltakHttpServer") {
 		val requestPredicate = { req: RecordedRequest ->
 			req.path == "/api/tiltaksarrangor/deltaker/bruker-info"
 				&& req.method == "POST"
-				&& req.getBodyAsString() == """{"personident": "$personIdent"}"""
+				&& req.getBodyAsString() == """{"personident": "$personident"}"""
 		}
 
 		addResponseHandler(requestPredicate, response)

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
@@ -16,7 +16,7 @@ import okhttp3.mockwebserver.RecordedRequest
 class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 
 	fun mockHentPerson(person: PersonDbo) {
-		mockHentPerson(person.personIdent, TestData.lagPdlPerson(person))
+		mockHentPerson(person.personident, TestData.lagPdlPerson(person))
 	}
 
 	fun mockHentPerson(brukerFnr: String, mockPdlPerson: PdlPerson) {
@@ -108,7 +108,7 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 		return MockResponse().setResponseCode(200).setBody(body)
 	}
 
-	private fun createPdlBrukerResponse(personIdent: String, mockPdlPerson: PdlPerson): MockResponse {
+	private fun createPdlBrukerResponse(personident: String, mockPdlPerson: PdlPerson): MockResponse {
 		val body = toJsonString(
 			PdlQueries.HentPerson.Response(
 				errors = null,
@@ -122,7 +122,7 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 							emptyList()
 						}
 					),
-					PdlQueries.HentPerson.HentIdenter(listOf(PdlQueries.HentPerson.Ident(personIdent, false, "FOLKEREGISTERIDENT")))
+					PdlQueries.HentPerson.HentIdenter(listOf(PdlQueries.HentPerson.Ident(personident, false, "FOLKEREGISTERIDENT")))
 				),
 				extensions = null,
 			)

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepositoryTest.kt
@@ -49,17 +49,17 @@ class NavBrukerRepositoryTest {
 	}
 
 	@Test
-	fun `get(personIdent) - bruker finnes - returnerer bruker`() {
+	fun `get(personident) - bruker finnes - returnerer bruker`() {
 		val bruker = TestData.lagNavBruker()
 		testRepository.insertNavBruker(bruker)
 
-		val faktiskBruker = repository.get(bruker.person.personIdent)!!
+		val faktiskBruker = repository.get(bruker.person.personident)!!
 
 		sammenlign(faktiskBruker, bruker)
 	}
 
 	@Test
-	fun `get(personIdent) - søk med historisk ident, bruker finnes - returnerer bruker`() {
+	fun `get(personident) - søk med historisk ident, bruker finnes - returnerer bruker`() {
 		val bruker = TestData.lagNavBruker()
 		testRepository.insertNavBruker(bruker)
 
@@ -72,7 +72,7 @@ class NavBrukerRepositoryTest {
 	}
 
 	@Test
-	fun `get(personIdent) - bruker finnes ikke - returnerer null`() {
+	fun `get(personident) - bruker finnes ikke - returnerer null`() {
 		repository.get("FNR") shouldBe null
 	}
 
@@ -146,7 +146,7 @@ class NavBrukerRepositoryTest {
 		val bruker = TestData.lagNavBruker()
 		testRepository.insertNavBruker(bruker)
 
-		repository.finnBrukerId(bruker.person.personIdent) shouldBe bruker.id
+		repository.finnBrukerId(bruker.person.personident) shouldBe bruker.id
 	}
 
 	@Test
@@ -166,7 +166,7 @@ class NavBrukerRepositoryTest {
 
 		repository.delete(bruker.id)
 
-		repository.get(bruker.person.personIdent) shouldBe null
+		repository.get(bruker.person.personident) shouldBe null
 	}
 
 	private fun sammenlign(

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerServiceTest.kt
@@ -73,17 +73,17 @@ class NavBrukerServiceTest {
 		val kontaktinformasjon = Kontaktinformasjon("navbruker@gmail.com", "99900111")
 		val erSkjermet = false
 
-		every { repository.get(person.personIdent) } returns null
-		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
-		every { personService.hentEllerOpprettPerson(person.personIdent, personOpplysninger) } returns person.toModel()
-		every { navAnsattService.hentBrukersVeileder(person.personIdent) } returns veileder.toModel()
-		every { navEnhetService.hentNavEnhetForBruker(person.personIdent) } returns navEnhet.toModel()
-		every { krrProxyClient.hentKontaktinformasjon(person.personIdent) } returns Result.success(kontaktinformasjon)
-		every { poaoTilgangClient.erSkjermetPerson(person.personIdent) } returns ApiResult(result = erSkjermet, throwable = null)
+		every { repository.get(person.personident) } returns null
+		every { pdlClient.hentPerson(person.personident) } returns personOpplysninger
+		every { personService.hentEllerOpprettPerson(person.personident, personOpplysninger) } returns person.toModel()
+		every { navAnsattService.hentBrukersVeileder(person.personident) } returns veileder.toModel()
+		every { navEnhetService.hentNavEnhetForBruker(person.personident) } returns navEnhet.toModel()
+		every { krrProxyClient.hentKontaktinformasjon(person.personident) } returns Result.success(kontaktinformasjon)
+		every { poaoTilgangClient.erSkjermetPerson(person.personident) } returns ApiResult(result = erSkjermet, throwable = null)
 		every { rolleService.harRolle(person.id, Rolle.NAV_BRUKER) } returns false
 		mockExecuteWithoutResult(transactionTemplate)
 
-		val faktiskBruker = service.hentEllerOpprettNavBruker(person.personIdent)
+		val faktiskBruker = service.hentEllerOpprettNavBruker(person.personident)
 
 		faktiskBruker.person.id shouldBe person.id
 		faktiskBruker.navVeileder?.id shouldBe veileder.id
@@ -98,11 +98,11 @@ class NavBrukerServiceTest {
 		val person = TestData.lagPerson()
 		val personOpplysninger = TestData.lagPdlPerson(person, adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
-		every { repository.get(person.personIdent) } returns null
-		every { pdlClient.hentPerson(person.personIdent) } returns personOpplysninger
+		every { repository.get(person.personident) } returns null
+		every { pdlClient.hentPerson(person.personident) } returns personOpplysninger
 
 		assertThrows<IllegalStateException> {
-			service.hentEllerOpprettNavBruker(person.personIdent)
+			service.hentEllerOpprettNavBruker(person.personident)
 		}
 	}
 
@@ -127,14 +127,14 @@ class NavBrukerServiceTest {
 				"krr-telefon",
 			)
 
-		every { repository.finnBrukerId(bruker.person.personIdent) } returns bruker.id
-		every { repository.get(bruker.person.personIdent) } returns bruker
-		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) } returns Result.success(kontakinformasjon)
+		every { repository.finnBrukerId(bruker.person.personident) } returns bruker.id
+		every { repository.get(bruker.person.personident) } returns bruker
+		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) } returns Result.success(kontakinformasjon)
 		mockExecuteWithoutResult(transactionTemplate)
 
 		service.oppdaterKontaktinformasjon(listOf(bruker.person.toModel()))
 
-		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) }
+		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) }
 		verify(exactly = 1) { repository.upsert(
 				bruker.copy(telefon = kontakinformasjon.telefonnummer, epost = kontakinformasjon.epost)
 					.toModel()
@@ -151,16 +151,16 @@ class NavBrukerServiceTest {
 		)
 		val pdlTelefon = "pdl-telefon"
 
-		every { repository.finnBrukerId(bruker.person.personIdent) } returns bruker.id
-		every { pdlClient.hentTelefon(bruker.person.personIdent) } returns pdlTelefon
-		every { repository.get(bruker.person.personIdent) } returns bruker
-		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) } returns Result.success(kontakinformasjon)
+		every { repository.finnBrukerId(bruker.person.personident) } returns bruker.id
+		every { pdlClient.hentTelefon(bruker.person.personident) } returns pdlTelefon
+		every { repository.get(bruker.person.personident) } returns bruker
+		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) } returns Result.success(kontakinformasjon)
 		mockExecuteWithoutResult(transactionTemplate)
 
 		service.oppdaterKontaktinformasjon(listOf(bruker.person.toModel()))
 
-		verify(exactly = 1) { pdlClient.hentTelefon(bruker.person.personIdent) }
-		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) }
+		verify(exactly = 1) { pdlClient.hentTelefon(bruker.person.personident) }
+		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) }
 		verify(exactly = 1) { repository.upsert(
 			bruker.copy(telefon = pdlTelefon, epost = kontakinformasjon.epost)
 				.toModel()
@@ -172,13 +172,13 @@ class NavBrukerServiceTest {
 	fun `oppdaterKontaktInformasjon - krr feiler - oppdaterer ikke`() {
 		val bruker = TestData.lagNavBruker()
 
-		every { repository.finnBrukerId(bruker.person.personIdent) } returns bruker.id
-		every { repository.get(bruker.person.personIdent) } returns bruker
-		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) } returns Result.failure(RuntimeException())
+		every { repository.finnBrukerId(bruker.person.personident) } returns bruker.id
+		every { repository.get(bruker.person.personident) } returns bruker
+		every { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) } returns Result.failure(RuntimeException())
 
 		service.oppdaterKontaktinformasjon(listOf(bruker.person.toModel()))
 
-		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personIdent) }
+		verify(exactly = 1) { krrProxyClient.hentKontaktinformasjon(bruker.person.personident) }
 		verify(exactly = 0) { repository.upsert(any()) }
 	}
 

--- a/src/test/kotlin/no/nav/amt/person/service/nav_enhet/NavEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_enhet/NavEnhetServiceTest.kt
@@ -32,13 +32,13 @@ class NavEnhetServiceTest {
 	@Test
 	fun `hentNavEnhetForBruker - enhet finnes ikke - skal opprette enhet`() {
 		val enhet = TestData.lagNavEnhet()
-		val personIdent = "FNR"
+		val personident = "FNR"
 
-		every { veilarbarenaClient.hentBrukerOppfolgingsenhetId(personIdent) } returns enhet.enhetId
+		every { veilarbarenaClient.hentBrukerOppfolgingsenhetId(personident) } returns enhet.enhetId
 		every { navEnhetRepository.get(enhet.enhetId) } returns null
 		every { norgClient.hentNavEnhet(enhet.enhetId) } returns NorgNavEnhet(enhet.enhetId, enhet.navn)
 
-		val faktiskEnhet = service.hentNavEnhetForBruker(personIdent)!!
+		val faktiskEnhet = service.hentNavEnhetForBruker(personident)!!
 
 		faktiskEnhet.enhetId shouldBe enhet.enhetId
 		faktiskEnhet.navn shouldBe enhet.navn

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonRepositoryTest.kt
@@ -40,7 +40,7 @@ class PersonRepositoryTest {
 		val faktiskPerson = repository.get(person.id)
 
 		faktiskPerson.id shouldBe person.id
-		faktiskPerson.personIdent shouldBe  person.personIdent
+		faktiskPerson.personident shouldBe  person.personident
 		faktiskPerson.fornavn shouldBe person.fornavn
 		faktiskPerson.mellomnavn shouldBe person.mellomnavn
 		faktiskPerson.etternavn shouldBe person.etternavn
@@ -56,7 +56,7 @@ class PersonRepositoryTest {
 	}
 
 	@Test
-	fun `get(personIdent) - person finnes ikke - returnerer null`() {
+	fun `get(personident) - person finnes ikke - returnerer null`() {
 		repository.get(TestData.randomIdent()) shouldBe null
 	}
 
@@ -68,8 +68,8 @@ class PersonRepositoryTest {
 		testRepository.insertPerson(person2)
 
 		val personer = repository.getPersoner(listOf(
-			person1.personIdent,
-			person2.personIdent,
+			person1.personident,
+			person2.personident,
 			TestData.randomIdent()
 		))
 
@@ -86,14 +86,14 @@ class PersonRepositoryTest {
 		testRepository.insertPerson(person)
 		testRepository.insertPersonidenter(listOf(historiskIdent))
 
-		val personer = repository.getPersoner(listOf(historiskIdent.ident, person.personIdent))
+		val personer = repository.getPersoner(listOf(historiskIdent.ident, person.personident))
 
 		personer shouldHaveSize 1
 
 		val faktiskPerson = personer.first()
 
 		faktiskPerson.id shouldBe  person.id
-		faktiskPerson.personIdent shouldNotBe historiskIdent.ident
+		faktiskPerson.personident shouldNotBe historiskIdent.ident
 	}
 
 	@Test
@@ -106,7 +106,7 @@ class PersonRepositoryTest {
 	fun `upsert - ny person - inserter person`() {
 		val person = Person(
 			id = UUID.randomUUID(),
-			personIdent = TestData.randomIdent(),
+			personident = TestData.randomIdent(),
 			fornavn = "Fornavn",
 			mellomnavn = "Mellomnavn",
 			etternavn = "Etternavn",
@@ -117,7 +117,7 @@ class PersonRepositoryTest {
 		val faktiskPerson = repository.get(person.id)
 
 		faktiskPerson.id shouldBe person.id
-		faktiskPerson.personIdent shouldBe  person.personIdent
+		faktiskPerson.personident shouldBe  person.personident
 		faktiskPerson.fornavn shouldBe person.fornavn
 		faktiskPerson.mellomnavn shouldBe person.mellomnavn
 		faktiskPerson.etternavn shouldBe person.etternavn
@@ -134,7 +134,7 @@ class PersonRepositoryTest {
 
 		val oppdatertPerson = Person(
 				id = originalPerson.id,
-				personIdent = originalPerson.personIdent,
+				personident = originalPerson.personident,
 				fornavn = "Nytt",
 				mellomnavn = "Navn",
 				etternavn = "Med Mer",
@@ -145,7 +145,7 @@ class PersonRepositoryTest {
 		val faktiskPerson = repository.get(originalPerson.id)
 
 		faktiskPerson.id shouldBe originalPerson.id
-		faktiskPerson.personIdent shouldBe  originalPerson.personIdent
+		faktiskPerson.personident shouldBe  originalPerson.personident
 		faktiskPerson.fornavn shouldBe oppdatertPerson.fornavn
 		faktiskPerson.mellomnavn shouldBe oppdatertPerson.mellomnavn
 		faktiskPerson.etternavn shouldBe oppdatertPerson.etternavn
@@ -164,7 +164,7 @@ class PersonRepositoryTest {
 
 		val oppdatertPerson = Person(
 			id = originalPerson.id,
-			personIdent = "ny ident",
+			personident = "ny ident",
 			fornavn = "Nytt",
 			mellomnavn = "Navn",
 			etternavn = "Med Mer",
@@ -175,7 +175,7 @@ class PersonRepositoryTest {
 		val faktiskPerson = repository.get(originalPerson.id)
 
 		faktiskPerson.id shouldBe originalPerson.id
-		faktiskPerson.personIdent shouldBe  oppdatertPerson.personIdent
+		faktiskPerson.personident shouldBe  oppdatertPerson.personident
 		faktiskPerson.fornavn shouldBe oppdatertPerson.fornavn
 		faktiskPerson.mellomnavn shouldBe oppdatertPerson.mellomnavn
 		faktiskPerson.etternavn shouldBe oppdatertPerson.etternavn
@@ -190,7 +190,7 @@ class PersonRepositoryTest {
 
 		repository.delete(person.id)
 
-		repository.get(person.personIdent) shouldBe null
+		repository.get(person.personident) shouldBe null
 	}
 
 }

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
@@ -42,7 +42,7 @@ class PersonServiceTest {
 
 	@Test
 	fun `hentEllerOpprettPerson - personen finnes ikke - opprettes og returnere person`() {
-		val personIdent = TestData.randomIdent()
+		val personident = TestData.randomIdent()
 		val identType = IdentType.FOLKEREGISTERIDENT
 		val pdlPerson = PdlPerson(
 			fornavn = "Fornavn",
@@ -51,17 +51,17 @@ class PersonServiceTest {
 			telefonnummer = "81549300",
 			adressebeskyttelseGradering = null,
 			identer = listOf(
-				Personident(ident = personIdent, historisk = false, type = identType),
+				Personident(ident = personident, historisk = false, type = identType),
 				Personident(ident = TestData.randomIdent(), historisk = true, type = identType),
 			)
 		)
 
-		every { pdlClient.hentPerson(personIdent) } returns pdlPerson
-		every { repository.get(personIdent) } returns null
+		every { pdlClient.hentPerson(personident) } returns pdlPerson
+		every { repository.get(personident) } returns null
 		mockExecuteWithoutResult(transactionTemplate)
 
-		val person = service.hentEllerOpprettPerson(personIdent)
-		person.personIdent shouldBe personIdent
+		val person = service.hentEllerOpprettPerson(personident)
+		person.personident shouldBe personident
 		person.fornavn shouldBe pdlPerson.fornavn
 		person.mellomnavn shouldBe pdlPerson.mellomnavn
 		person.etternavn shouldBe pdlPerson.etternavn
@@ -76,7 +76,7 @@ class PersonServiceTest {
 		)
 
 		every { repository.getPersoner(identer.map { it.ident }) } returns
-			identer.map { TestData.lagPerson(personIdent = it.ident) }
+			identer.map { TestData.lagPerson(personident = it.ident) }
 		mockExecuteWithoutResult(transactionTemplate)
 
 		assertThrows<IllegalStateException> {

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonidentRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonidentRepositoryTest.kt
@@ -51,7 +51,7 @@ class PersonidentRepositoryTest {
 		testRepository.insertPerson(person)
 
 		val identer = listOf(
-			TestData.lagPersonident(person.personIdent, historisk = true),
+			TestData.lagPersonident(person.personident, historisk = true),
 			TestData.lagPersonident(TestData.randomIdent(), historisk = false),
 		)
 


### PR DESCRIPTION
Det har plaget meg litt i det siste at casingen for personident ofte er skrevet som `personIdent`, nå som i ettertid jeg har lært at det er ett ord 😅 

Tenker det er nå eller aldri for å fikse det i hele appen, før kafka topics blir tatt i bruk.