### PR TITLE
Returner nav-ansatt fra upsert

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattRepository.kt
@@ -5,7 +5,7 @@ import no.nav.amt.person.service.utils.sqlParameters
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
-import java.util.*
+import java.util.UUID
 
 @Component
 class NavAnsattRepository(
@@ -53,7 +53,7 @@ class NavAnsattRepository(
 	}
 
 
-	fun upsert(navAnsatt: NavAnsatt) {
+	fun upsert(navAnsatt: NavAnsatt): NavAnsattDbo {
 		val parameters = sqlParameters(
 			"id" to navAnsatt.id,
 			"navIdent" to navAnsatt.navIdent,
@@ -62,7 +62,7 @@ class NavAnsattRepository(
 			"epost" to navAnsatt.epost,
 		)
 
-		template.update(upsertSql, parameters)
+		return template.query("$upsertSql returning *", parameters, rowMapper).first()
 	}
 
 	fun upsertMany(ansatte: List<NavAnsatt>) {

--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattService.kt
@@ -4,7 +4,7 @@ import no.nav.amt.person.service.clients.nom.NomClient
 import no.nav.amt.person.service.clients.veilarboppfolging.VeilarboppfolgingClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
  class NavAnsattService(
@@ -46,9 +46,7 @@ import java.util.*
 				telefon = nyNavAnsatt.telefonnummer,
 			)
 
-		navAnsattRepository.upsert(ansatt)
-
-		return ansatt
+		return navAnsattRepository.upsert(ansatt).toModel()
 	}
 
 

--- a/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattServiceTest.kt
@@ -30,7 +30,7 @@ class NavAnsattServiceTest {
 
 	@Test
 	fun `hentHellerOpprettAnsatt - ansatt finnes ikke - oppretter og returnerer ansatt`() {
-		val ansatt = TestData.lagNavAnsatt().toModel()
+		val ansatt = TestData.lagNavAnsatt()
 
 		every { navAnsattRepository.get(ansatt.navIdent) } returns null
 		every { nomClient.hentNavAnsatt(ansatt.navIdent) } returns NomNavAnsatt(
@@ -39,6 +39,7 @@ class NavAnsattServiceTest {
 			telefonnummer = ansatt.telefon,
 			epost = ansatt.epost,
 		)
+		every { navAnsattRepository.upsert(any()) } returns ansatt
 
 		val faktiskAnsatt = service.hentEllerOpprettAnsatt(ansatt.navIdent)
 


### PR DESCRIPTION
On conflict på nav_ident gjorde at man ikke returnerte riktig id når det oppstod en race condition som gjorde at samme ansatt ble forsøkt opprettet to ganger samtidig. Nå skal metoden returnere det objektet som finnes i databasen om dette skjer og det skal ikke ha noe å si hvem som var først.