### PR TITLE
Upsert og publiser nav-ansatte kun når endringer har skjedd 

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattService.kt
@@ -31,6 +31,11 @@ class NavAnsattService(
 		return ansatt
 	}
 
+	fun upsertMany(ansatte: List<NavAnsatt>) {
+		navAnsattRepository.upsertMany(ansatte)
+		ansatte.forEach { kafkaProducerService.publiserNavAnsatt(it) }
+	}
+
 
 	fun hentEllerOpprettAnsatt(navIdent: String): NavAnsatt {
 		val navAnsatt = navAnsattRepository.get(navIdent)

--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
@@ -7,17 +7,17 @@ import org.springframework.stereotype.Component
 
 @Component
 class NavAnsattUpdater(
-	private val repository: NavAnsattRepository,
+	private val navAnsattService: NavAnsattService,
 	private val nomClient: NomClient,
 ) {
 
 	private val log = LoggerFactory.getLogger(javaClass)
 
 	fun oppdaterAlle(batchSize: Int = 100) {
-		val ansattBatcher = repository.getAll().chunked(batchSize)
+		val ansattBatcher = navAnsattService.getAll().chunked(batchSize)
 
 		ansattBatcher.forEach { batch ->
-			val ansatte = batch.associate { it.navIdent to AnsattSomSkalOppdateres(it.toModel(), false) }
+			val ansatte = batch.associate { it.navIdent to AnsattSomSkalOppdateres(it, false) }
 			val nomResultat = nomClient.hentNavAnsatte(ansatte.keys.toList())
 
 			val oppdaterteAnsatte = nomResultat.mapNotNull { nomAnsatt ->
@@ -38,7 +38,7 @@ class NavAnsattUpdater(
 				}
 			}
 
-			repository.upsertMany(oppdaterteAnsatte)
+			navAnsattService.upsertMany(oppdaterteAnsatte)
 
 			ansatte.forEach { (navIdent, ansatt) ->
 				if (!ansatt.erSjekket) {

--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
@@ -1,9 +1,9 @@
 package no.nav.amt.person.service.nav_ansatt
 
 import no.nav.amt.person.service.clients.nom.NomClient
+import no.nav.amt.person.service.clients.nom.NomNavAnsatt
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 class NavAnsattUpdater(
@@ -17,34 +17,45 @@ class NavAnsattUpdater(
 		val ansattBatcher = repository.getAll().chunked(batchSize)
 
 		ansattBatcher.forEach { batch ->
-			val ansatte = batch.associate { it.navIdent to AnsattSomSkalOppdateres(it.id, false) }
+			val ansatte = batch.associate { it.navIdent to AnsattSomSkalOppdateres(it.toModel(), false) }
 			val nomResultat = nomClient.hentNavAnsatte(ansatte.keys.toList())
 
-			val oppdaterteAnsatte = nomResultat.map { nomAnsatt ->
-				ansatte[nomAnsatt.navIdent]?.let {
-					it.erOppdatert = true
+			val oppdaterteAnsatte = nomResultat.mapNotNull { nomAnsatt ->
+
+				val ansatt = ansatte[nomAnsatt.navIdent] ?: return@mapNotNull null
+				ansatt.erSjekket = true
+
+				return@mapNotNull if (ansatt.lagretAnsatt.skalOppdateres(nomAnsatt)) {
 					NavAnsatt(
-						id = it.id,
+						id = ansatt.lagretAnsatt.id,
 						navIdent = nomAnsatt.navIdent,
 						navn = nomAnsatt.navn,
 						epost = nomAnsatt.epost,
 						telefon = nomAnsatt.telefonnummer,
 					)
-				} ?: throw IllegalStateException("Ukjent NAVident ${nomAnsatt.navIdent} i respons fra Nom")
+				} else {
+					null
+				}
 			}
 
 			repository.upsertMany(oppdaterteAnsatte)
 
-			ansatte.forEach { navIdent, ansattSomSkalOppdateres ->
-				if (!ansattSomSkalOppdateres.erOppdatert) {
-					log.warn("Fant ikke nav ansatt med ident=${navIdent} id=${ansattSomSkalOppdateres.id} i NOM")
+			ansatte.forEach { (navIdent, ansatt) ->
+				if (!ansatt.erSjekket) {
+					log.warn("Fant ikke nav ansatt med ident=${navIdent} id=${ansatt.lagretAnsatt.id} i NOM")
 				}
 			}
 		}
 	}
 
 	data class AnsattSomSkalOppdateres(
-		val id: UUID,
-		var erOppdatert: Boolean,
+		val lagretAnsatt: NavAnsatt,
+		var erSjekket: Boolean,
 	)
+}
+
+private fun NavAnsatt.skalOppdateres(nomNavAnsatt: NomNavAnsatt): Boolean {
+	return this.navn != nomNavAnsatt.navn ||
+		this.epost != nomNavAnsatt.epost ||
+		this.telefon != nomNavAnsatt.telefonnummer
 }

--- a/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdater.kt
@@ -21,21 +21,7 @@ class NavAnsattUpdater(
 			val nomResultat = nomClient.hentNavAnsatte(ansatte.keys.toList())
 
 			val oppdaterteAnsatte = nomResultat.mapNotNull { nomAnsatt ->
-
-				val ansatt = ansatte[nomAnsatt.navIdent] ?: return@mapNotNull null
-				ansatt.erSjekket = true
-
-				return@mapNotNull if (ansatt.lagretAnsatt.skalOppdateres(nomAnsatt)) {
-					NavAnsatt(
-						id = ansatt.lagretAnsatt.id,
-						navIdent = nomAnsatt.navIdent,
-						navn = nomAnsatt.navn,
-						epost = nomAnsatt.epost,
-						telefon = nomAnsatt.telefonnummer,
-					)
-				} else {
-					null
-				}
+				ansatte[nomAnsatt.navIdent]?.let { finnOppdatering(it, nomAnsatt) }
 			}
 
 			navAnsattService.upsertMany(oppdaterteAnsatte)
@@ -45,6 +31,25 @@ class NavAnsattUpdater(
 					log.warn("Fant ikke nav ansatt med ident=${navIdent} id=${ansatt.lagretAnsatt.id} i NOM")
 				}
 			}
+		}
+	}
+
+	private fun finnOppdatering(
+		ansatt: AnsattSomSkalOppdateres,
+		nomAnsatt: NomNavAnsatt,
+	): NavAnsatt? {
+		ansatt.erSjekket = true
+
+		return if (ansatt.lagretAnsatt.skalOppdateres(nomAnsatt)) {
+			NavAnsatt(
+				id = ansatt.lagretAnsatt.id,
+				navIdent = nomAnsatt.navIdent,
+				navn = nomAnsatt.navn,
+				epost = nomAnsatt.epost,
+				telefon = nomAnsatt.telefonnummer,
+			)
+		} else {
+			null
 		}
 	}
 

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavAnsattProducerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavAnsattProducerTest.kt
@@ -8,6 +8,8 @@ import no.nav.amt.person.service.kafka.config.KafkaTopicProperties
 import no.nav.amt.person.service.kafka.producer.KafkaProducerService
 import no.nav.amt.person.service.kafka.producer.dto.NavAnsattDtoV1
 import no.nav.amt.person.service.nav_ansatt.NavAnsatt
+import no.nav.amt.person.service.nav_ansatt.NavAnsattService
+import no.nav.amt.person.service.nav_ansatt.NavAnsattUpdater
 import no.nav.amt.person.service.utils.JsonUtils.toJsonString
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,6 +21,12 @@ class NavAnsattProducerTest: IntegrationTestBase() {
 
 	@Autowired
 	lateinit var kafkaTopicProperties: KafkaTopicProperties
+
+	@Autowired
+	lateinit var navAnsattService: NavAnsattService
+
+	@Autowired
+	lateinit var navAnsattUpdater: NavAnsattUpdater
 
 	@Test
 	fun `publiserNavAnsatt - skal publisere ansatt med riktig key og value`() {
@@ -34,6 +42,41 @@ class NavAnsattProducerTest: IntegrationTestBase() {
 		record.key() shouldBe ansatt.id.toString()
 		record.value() shouldBe forventetValue
 
+	}
+
+	@Test
+	fun `publiserNavAnsatt - ansatt er oppdatert - skal publisere ny melding`() {
+		val ansatt = TestData.lagNavAnsatt()
+		testDataRepository.insertNavAnsatt(ansatt)
+
+		val oppdatertAnsatt = ansatt.copy(navn = "nytt navn", telefon = "nytt nummer", epost = "ny@epost.no").toModel()
+		navAnsattService.upsert(oppdatertAnsatt)
+
+		val record = consume(kafkaTopicProperties.amtNavAnsattPersonaliaTopic)!!
+			.first { it.key() == ansatt.id.toString() }
+
+		val forventetValue = ansattTilV1Json(oppdatertAnsatt)
+
+		record.key() shouldBe ansatt.id.toString()
+		record.value() shouldBe forventetValue
+	}
+
+	@Test
+	fun `publiserNavAnsatt - flere ansatte sjekkes for oppdatering - skal publisere melding kun for de med endring`() {
+		val endretAnsatt = TestData.lagNavAnsatt()
+		testDataRepository.insertNavAnsatt(endretAnsatt)
+		val uendretAnsatt = TestData.lagNavAnsatt()
+		testDataRepository.insertNavAnsatt(uendretAnsatt)
+
+		mockNomHttpServer.mockHentNavAnsatt(endretAnsatt.toModel().copy(navn = "nytt navn"))
+		mockNomHttpServer.mockHentNavAnsatt(uendretAnsatt.toModel())
+
+		navAnsattUpdater.oppdaterAlle()
+
+		val records = consume(kafkaTopicProperties.amtNavAnsattPersonaliaTopic)!!
+
+		records.any { it.key() == endretAnsatt.id.toString() } shouldBe true
+		records.any { it.key() == uendretAnsatt.id.toString() } shouldBe false
 	}
 
 	private fun ansattTilV1Json(ansatt: NavAnsatt): String {

--- a/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdaterTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdaterTest.kt
@@ -51,8 +51,47 @@ class NavAnsattUpdaterTest {
 			} shouldBe true
 
 		}
+	}
 
-		verify(exactly = 1) { repository.upsertMany(listOf(ansatt1.toModel())) }
+	@Test
+	fun `oppdaterAlle - ansatt er ikke endret - oppdaterer ikke`() {
+		val ansatt = TestData.lagNavAnsatt()
+
+		every { repository.getAll() } returns listOf(ansatt)
+		every { nomClient.hentNavAnsatte(listOf(ansatt.navIdent)) } returns listOf(
+			NomNavAnsatt(
+				navIdent = ansatt.navIdent,
+				navn = ansatt.navn,
+				telefonnummer = ansatt.telefon,
+				epost = ansatt.epost,
+			)
+		)
+
+		updater.oppdaterAlle()
+
+		verify(exactly = 0) { repository.upsertMany(listOf(ansatt.toModel())) }
+	}
+
+	@Test
+	fun `oppdaterAlle - ansatt er endret - oppdaterer ansatt`() {
+		val ansatt = TestData.lagNavAnsatt()
+		val oppdatertAnsatt = ansatt.toModel().copy(navn = "Foo Bar")
+
+		every { repository.getAll() } returns listOf(ansatt)
+		every { nomClient.hentNavAnsatte(listOf(ansatt.navIdent)) } returns listOf(
+			NomNavAnsatt(
+				navIdent = oppdatertAnsatt.navIdent,
+				navn = oppdatertAnsatt.navn,
+				telefonnummer = oppdatertAnsatt.telefon,
+				epost = oppdatertAnsatt.epost,
+			)
+		)
+
+		updater.oppdaterAlle()
+
+		verify(exactly = 1) {
+			repository.upsertMany(listOf(oppdatertAnsatt))
+		}
 	}
 
 }

--- a/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdaterTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_ansatt/NavAnsattUpdaterTest.kt
@@ -12,24 +12,24 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class NavAnsattUpdaterTest {
-	lateinit var repository: NavAnsattRepository
+	lateinit var navAnsattService: NavAnsattService
 	lateinit var nomClient: NomClientImpl
 	lateinit var updater: NavAnsattUpdater
 
 	@BeforeEach
 	fun setup() {
-		repository = mockk(relaxUnitFun = true)
+		navAnsattService = mockk(relaxUnitFun = true)
 		nomClient = mockk()
 
-		updater = NavAnsattUpdater(repository, nomClient)
+		updater = NavAnsattUpdater(navAnsattService, nomClient)
 	}
 
 	@Test
 	fun `oppdaterAlle - navIdent mangler hos Nom - logger warning`() {
-		val ansatt1 = TestData.lagNavAnsatt()
-		val ansatt2 = TestData.lagNavAnsatt()
+		val ansatt1 = TestData.lagNavAnsatt().toModel()
+		val ansatt2 = TestData.lagNavAnsatt().toModel()
 
-		every { repository.getAll() } returns listOf(ansatt1, ansatt2)
+		every { navAnsattService.getAll() } returns listOf(ansatt1, ansatt2)
 		every { nomClient.hentNavAnsatte(listOf(ansatt1.navIdent, ansatt2.navIdent)) } returns listOf(
 			NomNavAnsatt(
 				navIdent = ansatt1.navIdent,
@@ -55,9 +55,9 @@ class NavAnsattUpdaterTest {
 
 	@Test
 	fun `oppdaterAlle - ansatt er ikke endret - oppdaterer ikke`() {
-		val ansatt = TestData.lagNavAnsatt()
+		val ansatt = TestData.lagNavAnsatt().toModel()
 
-		every { repository.getAll() } returns listOf(ansatt)
+		every { navAnsattService.getAll() } returns listOf(ansatt)
 		every { nomClient.hentNavAnsatte(listOf(ansatt.navIdent)) } returns listOf(
 			NomNavAnsatt(
 				navIdent = ansatt.navIdent,
@@ -69,15 +69,15 @@ class NavAnsattUpdaterTest {
 
 		updater.oppdaterAlle()
 
-		verify(exactly = 0) { repository.upsertMany(listOf(ansatt.toModel())) }
+		verify(exactly = 0) { navAnsattService.upsertMany(listOf(ansatt)) }
 	}
 
 	@Test
 	fun `oppdaterAlle - ansatt er endret - oppdaterer ansatt`() {
-		val ansatt = TestData.lagNavAnsatt()
-		val oppdatertAnsatt = ansatt.toModel().copy(navn = "Foo Bar")
+		val ansatt = TestData.lagNavAnsatt().toModel()
+		val oppdatertAnsatt = ansatt.copy(navn = "Foo Bar")
 
-		every { repository.getAll() } returns listOf(ansatt)
+		every { navAnsattService.getAll() } returns listOf(ansatt)
 		every { nomClient.hentNavAnsatte(listOf(ansatt.navIdent)) } returns listOf(
 			NomNavAnsatt(
 				navIdent = oppdatertAnsatt.navIdent,
@@ -90,7 +90,7 @@ class NavAnsattUpdaterTest {
 		updater.oppdaterAlle()
 
 		verify(exactly = 1) {
-			repository.upsertMany(listOf(oppdatertAnsatt))
+			navAnsattService.upsertMany(listOf(oppdatertAnsatt))
 		}
 	}
 


### PR DESCRIPTION
Forhindrer at vi republiserer nav-ansatte og at modified_at blir endret hver dag uavhengig om endringer har skjedd.