### PR TITLE
Adresse

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 	implementation("com.squareup.okhttp3:okhttp:$okhttp3Version")
 	implementation("org.flywaydb:flyway-core:$flywayVersion")
+	implementation("org.postgresql:postgresql")
 
 	implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
 	implementation("com.github.navikt.common-java-modules:log:$commonVersion")

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
@@ -60,6 +60,8 @@ class PdlClient(
 
 			logPdlWarnings(gqlResponse.extensions?.warnings)
 
+			log.info("Hentet perosn for personident $personident, respons: $body")
+
 			if (gqlResponse.data == null) {
 				throw RuntimeException("PDL respons inneholder ikke data")
 			}

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
@@ -60,8 +60,6 @@ class PdlClient(
 
 			logPdlWarnings(gqlResponse.extensions?.warnings)
 
-			log.info("Hentet perosn for personident $personident, respons: $body")
-
 			if (gqlResponse.data == null) {
 				throw RuntimeException("PDL respons inneholder ikke data")
 			}

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClient.kt
@@ -1,8 +1,17 @@
 package no.nav.amt.person.service.clients.pdl
 
+import no.nav.amt.person.service.person.model.Adresse
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
+import no.nav.amt.person.service.person.model.Bostedsadresse
 import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.person.model.Kontaktadresse
+import no.nav.amt.person.service.person.model.Matrikkeladresse
+import no.nav.amt.person.service.person.model.Oppholdsadresse
 import no.nav.amt.person.service.person.model.Personident
+import no.nav.amt.person.service.person.model.Postboksadresse
+import no.nav.amt.person.service.person.model.Vegadresse
+import no.nav.amt.person.service.poststed.Postnummer
+import no.nav.amt.person.service.poststed.PoststedRepository
 import no.nav.amt.person.service.utils.GraphqlUtils
 import no.nav.amt.person.service.utils.GraphqlUtils.GraphqlResponse
 import no.nav.amt.person.service.utils.JsonUtils.fromJsonString
@@ -19,6 +28,7 @@ class PdlClient(
 	private val baseUrl: String,
 	private val tokenProvider: Supplier<String>,
 	private val httpClient: OkHttpClient = baseClient(),
+	private val poststedRepository: PoststedRepository
 ) {
 
 	private val log = LoggerFactory.getLogger(javaClass)
@@ -169,9 +179,9 @@ class PdlClient(
 			etternavn = navn.etternavn,
 			telefonnummer = telefonnummer,
 			adressebeskyttelseGradering = diskresjonskode,
-			identer = response.hentIdenter.identer.map { Personident(it.ident, it.historisk, IdentType.valueOf(it.gruppe)) }
+			identer = response.hentIdenter.identer.map { Personident(it.ident, it.historisk, IdentType.valueOf(it.gruppe)) },
+			adresse = getAdresse(response.hentPerson)
 		)
-
 	}
 
 	private fun getTelefonnummer(telefonnummere: List<PdlQueries.Attribute.Telefonnummer>): String? {
@@ -188,6 +198,125 @@ class PdlClient(
 			"UGRADERT" -> AdressebeskyttelseGradering.UGRADERT
 			else -> null
 		}
+	}
+
+	private fun getAdresse(hentPersonResponse: PdlQueries.HentPerson.HentPerson): Adresse? {
+		val kontaktadresseFraPdl = hentPersonResponse.kontaktadresse.firstOrNull()
+		val bostedsadresseFraPdl = hentPersonResponse.bostedsadresse.firstOrNull()
+		val oppholdsadresseFraPdl = hentPersonResponse.oppholdsadresse.firstOrNull()
+
+		val unikePostnummer = listOfNotNull(
+			kontaktadresseFraPdl?.vegadresse?.postnummer,
+			kontaktadresseFraPdl?.postboksadresse?.postnummer,
+			bostedsadresseFraPdl?.vegadresse?.postnummer,
+			bostedsadresseFraPdl?.matrikkeladresse?.postnummer,
+			oppholdsadresseFraPdl?.vegadresse?.postnummer,
+			oppholdsadresseFraPdl?.matrikkeladresse?.postnummer
+		).distinct()
+
+		val poststeder = poststedRepository.getPoststeder(unikePostnummer)
+
+		if (poststeder.isEmpty()) {
+			return null
+		}
+
+		val adresse = Adresse(
+			bostedsadresse = bostedsadresseFraPdl?.toBostedsadresse(poststeder),
+			oppholdsadresse = oppholdsadresseFraPdl?.toOppholdsadresse(poststeder),
+			kontaktadresse = kontaktadresseFraPdl?.toKontaktadresse(poststeder)
+		)
+
+		if (adresse.bostedsadresse == null && adresse.oppholdsadresse == null && adresse.kontaktadresse == null) {
+			return null
+		}
+		return adresse
+	}
+
+	private fun PdlQueries.Attribute.Bostedsadresse.toBostedsadresse(poststeder: List<Postnummer>): Bostedsadresse? {
+		if (vegadresse == null && matrikkeladresse == null) {
+			return null
+		}
+		val bostedsadresse = Bostedsadresse(
+			coAdressenavn = coAdressenavn,
+			vegadresse = vegadresse?.toVegadresse(poststeder),
+			matrikkeladresse = matrikkeladresse?.toMatrikkeladresse(poststeder)
+		)
+		if (bostedsadresse.vegadresse == null && bostedsadresse.matrikkeladresse == null) {
+			return null
+		}
+		return bostedsadresse
+	}
+
+	private fun PdlQueries.Attribute.Oppholdsadresse.toOppholdsadresse(poststeder: List<Postnummer>): Oppholdsadresse? {
+		if (vegadresse == null && matrikkeladresse == null) {
+			return null
+		}
+		val oppholdsadresse = Oppholdsadresse(
+			coAdressenavn = coAdressenavn,
+			vegadresse = vegadresse?.toVegadresse(poststeder),
+			matrikkeladresse = matrikkeladresse?.toMatrikkeladresse(poststeder)
+		)
+		if (oppholdsadresse.vegadresse == null && oppholdsadresse.matrikkeladresse == null) {
+			return null
+		}
+		return oppholdsadresse
+	}
+
+	private fun PdlQueries.Attribute.Kontaktadresse.toKontaktadresse(poststeder: List<Postnummer>): Kontaktadresse? {
+		if (vegadresse == null && postboksadresse == null) {
+			return null
+		}
+		val kontaktadresse = Kontaktadresse(
+			coAdressenavn = coAdressenavn,
+			vegadresse = vegadresse?.toVegadresse(poststeder),
+			postboksadresse = postboksadresse?.toPostboksadresse(poststeder)
+		)
+		if (kontaktadresse.vegadresse == null && kontaktadresse.postboksadresse == null) {
+			return null
+		}
+		return kontaktadresse
+	}
+
+	private fun PdlQueries.Attribute.Vegadresse.toVegadresse(poststeder: List<Postnummer>): Vegadresse? {
+		if (postnummer == null) {
+			return null
+		}
+		val poststed = poststeder.find { it.postnummer == postnummer } ?: return null
+
+		return Vegadresse(
+			husnummer = husnummer,
+			husbokstav = husbokstav,
+			adressenavn = adressenavn,
+			tilleggsnavn = tilleggsnavn,
+			postnummer = postnummer,
+			poststed = poststed.poststed
+		)
+	}
+
+	private fun PdlQueries.Attribute.Matrikkeladresse.toMatrikkeladresse(poststeder: List<Postnummer>): Matrikkeladresse? {
+		if (postnummer == null) {
+			return null
+		}
+		val poststed = poststeder.find { it.postnummer == postnummer } ?: return null
+
+		return Matrikkeladresse(
+			tilleggsnavn = tilleggsnavn,
+			postnummer = postnummer,
+			poststed = poststed.poststed
+		)
+	}
+
+	private fun PdlQueries.Attribute.Postboksadresse.toPostboksadresse(poststeder: List<Postnummer>): Postboksadresse? {
+		if (postnummer == null) {
+			return null
+		}
+		val poststed = poststeder.find { it.postnummer == postnummer } ?: return null
+
+		return Postboksadresse(
+			postboks = postboks,
+			postnummer = postnummer,
+			poststed = poststed.poststed
+		)
 	}
 
 	private fun throwPdlApiErrors(response: GraphqlResponse<*, PdlQueries.PdlErrorExtension>) {

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientConfig.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.person.service.clients.pdl
 
+import no.nav.amt.person.service.poststed.PoststedRepository
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -15,10 +16,11 @@ class PdlClientConfig {
 	lateinit var scope: String
 
 	@Bean
-	fun pdlClient(machineToMachineTokenClient: MachineToMachineTokenClient): PdlClient {
+	fun pdlClient(machineToMachineTokenClient: MachineToMachineTokenClient, poststedRepository: PoststedRepository): PdlClient {
 		return PdlClient(
 			baseUrl = url,
 			tokenProvider = { machineToMachineTokenClient.createMachineToMachineToken(scope) },
+			poststedRepository = poststedRepository
 		)
 	}
 

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlPerson.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.person.service.clients.pdl
 
+import no.nav.amt.person.service.person.model.Adresse
 import no.nav.amt.person.service.person.model.Personident
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
 
@@ -9,5 +10,6 @@ data class PdlPerson(
 	val etternavn: String,
 	val telefonnummer: String?,
 	val adressebeskyttelseGradering: AdressebeskyttelseGradering?,
-	val identer: List<Personident>
+	val identer: List<Personident>,
+	val adresse: Adresse?
 )

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
@@ -28,7 +28,7 @@ object PdlQueries {
 		val query: String?,
 		val id: String,
 		val message: String,
-		val details: String?
+		val details: Any?
 	)
 
 	data class Extensions(

--- a/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/clients/pdl/PdlQueries.kt
@@ -51,6 +51,48 @@ object PdlQueries {
 				}
 				adressebeskyttelse(historikk: false) {
 				  gradering
+				},
+				bostedsadresse(historikk: false) {
+				  coAdressenavn
+				  vegadresse {
+					husnummer
+					husbokstav
+					adressenavn
+					tilleggsnavn
+					postnummer
+				  }
+				  matrikkeladresse {
+				 	tilleggsnavn
+				 	postnummer
+				  }
+				}
+				oppholdsadresse(historikk: false) {
+				  coAdressenavn
+				  vegadresse {
+				  	husnummer
+				  	husbokstav
+				  	adressenavn
+				  	tilleggsnavn
+				  	postnummer
+				  }
+				  matrikkeladresse {
+				  	tilleggsnavn
+				  	postnummer
+				  }
+				}
+				kontaktadresse(historikk: false) {
+				  coAdressenavn
+				  vegadresse {
+					husnummer
+					husbokstav
+					adressenavn
+					tilleggsnavn
+					postnummer
+				  }
+				  postboksadresse {
+				 	postboks
+				 	postnummer
+				  }
 				}
 			  },
 			  hentIdenter(ident: ${"$"}ident, grupper: [FOLKEREGISTERIDENT, AKTORID, NPID], historikk:true) {
@@ -77,7 +119,10 @@ object PdlQueries {
 		data class HentPerson(
 			val navn: List<Attribute.Navn>,
 			val telefonnummer: List<Attribute.Telefonnummer>,
-			val adressebeskyttelse: List<Attribute.Adressebeskyttelse>
+			val adressebeskyttelse: List<Attribute.Adressebeskyttelse>,
+			val bostedsadresse: List<Attribute.Bostedsadresse>,
+			val oppholdsadresse: List<Attribute.Oppholdsadresse>,
+			val kontaktadresse: List<Attribute.Kontaktadresse>
 		)
 
 		data class HentIdenter(
@@ -193,6 +238,41 @@ object PdlQueries {
 			val prioritet: Int,
 		)
 
+		data class Bostedsadresse(
+			val coAdressenavn: String?,
+			val vegadresse: Vegadresse?,
+			val matrikkeladresse: Matrikkeladresse?
+		)
+
+		data class Oppholdsadresse(
+			val coAdressenavn: String?,
+			val vegadresse: Vegadresse?,
+			val matrikkeladresse: Matrikkeladresse?
+		)
+
+		data class Kontaktadresse(
+			val coAdressenavn: String?,
+			val vegadresse: Vegadresse?,
+			val postboksadresse: Postboksadresse?
+		)
+
+		data class Vegadresse(
+			val husnummer: String?,
+			val husbokstav: String?,
+			val adressenavn: String?,
+			val tilleggsnavn: String?,
+			val postnummer: String?
+		)
+
+		data class Matrikkeladresse(
+			val tilleggsnavn: String?,
+			val postnummer: String?
+		)
+
+		data class Postboksadresse(
+			val postboks: String,
+			val postnummer: String?
+		)
 	}
 
 	data class Variables(

--- a/src/main/kotlin/no/nav/amt/person/service/controller/dto/NavBrukerDto.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/controller/dto/NavBrukerDto.kt
@@ -2,6 +2,7 @@ package no.nav.amt.person.service.controller.dto
 
 import no.nav.amt.person.service.nav_bruker.NavBruker
 import no.nav.amt.person.service.nav_enhet.NavEnhet
+import no.nav.amt.person.service.person.model.Adresse
 import java.util.UUID
 
 data class NavBrukerDto (
@@ -15,6 +16,7 @@ data class NavBrukerDto (
 	val telefon: String?,
 	val epost: String?,
 	val erSkjermet: Boolean,
+	val adresse: Adresse?
 )
 
 fun NavBruker.toDto() = NavBrukerDto(
@@ -28,4 +30,5 @@ fun NavBruker.toDto() = NavBrukerDto(
 	telefon = this.telefon,
 	epost = this.epost,
 	erSkjermet = this.erSkjermet,
+	adresse = this.adresse
 )

--- a/src/main/kotlin/no/nav/amt/person/service/internal/InternalController.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/internal/InternalController.kt
@@ -88,6 +88,19 @@ class InternalController(
 	}
 
 	@Unprotected
+	@GetMapping("/nav-brukere/republiser/{dollyIdent}")
+	fun republiserNavBruker(
+		servlet: HttpServletRequest,
+		@PathVariable("dollyIdent") dollyIdent: String
+	) {
+		if (isDev() && isInternal(servlet)) {
+			republiserNavBruker(dollyIdent)
+		} else {
+			throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+		}
+	}
+
+	@Unprotected
 	@GetMapping("/arrangor-ansatte/republiser")
 	fun republiserArrangorAnsatte(
 		servlet: HttpServletRequest,
@@ -151,6 +164,11 @@ class InternalController(
 		if (totalHandled > 0)
 			log.info("Handled $totalHandled nav-bruker records in ${duration.toSeconds()}.${duration.toMillisPart()} seconds.")
 
+	}
+
+	private fun republiserNavBruker(personident: String) {
+		val bruker = navBrukerRepository.get(personident) ?: throw RuntimeException("Fant ikke bruker")
+		kafkaProducerService.publiserNavBruker(bruker.toModel())
 	}
 
 	private fun isInternal(servlet: HttpServletRequest): Boolean {

--- a/src/main/kotlin/no/nav/amt/person/service/kafka/ingestor/LeesahIngestor.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/ingestor/LeesahIngestor.kt
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service
 enum class  OpplysningsType {
 	NAVN_V1,
 	ADRESSEBESKYTTELSE_V1,
+	KONTAKTADRESSE_V1,
+	BOSTEDSADRESSE_V1
 }
 
 @Service
@@ -28,6 +30,8 @@ class LeesahIngestor(
 			OpplysningsType.NAVN_V1.toString() -> handterNavn(personhendelse.personidenter, personhendelse.navn)
 			OpplysningsType.ADRESSEBESKYTTELSE_V1.toString() ->
 				handterAdressebeskyttelse(personhendelse.personidenter, personhendelse.adressebeskyttelse)
+			OpplysningsType.BOSTEDSADRESSE_V1.toString() -> handterAdresse(personhendelse.personidenter)
+			OpplysningsType.KONTAKTADRESSE_V1.toString() -> handterAdresse(personhendelse.personidenter)
 		}
 	}
 
@@ -67,6 +71,14 @@ class LeesahIngestor(
 			))
 		}
 		navBrukerService.oppdaterKontaktinformasjon(personer)
+	}
+
+	private fun handterAdresse(personidenter: List<String>) {
+		val personer = personService.hentPersoner(personidenter)
+
+		if (personer.isEmpty()) return
+
+		navBrukerService.oppdaterAdresse(personer)
 	}
 
 	private fun erAddressebeskyttet(gradering: Gradering?): Boolean {

--- a/src/main/kotlin/no/nav/amt/person/service/kafka/producer/KafkaProducerService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/producer/KafkaProducerService.kt
@@ -33,6 +33,7 @@ class KafkaProducerService(
 			telefon = navBruker.telefon,
 			epost = navBruker.epost,
 			erSkjermet = navBruker.erSkjermet,
+			adresse = navBruker.adresse
 		)
 
 		val key = navBruker.person.id.toString()

--- a/src/main/kotlin/no/nav/amt/person/service/kafka/producer/dto/NavBrukerDtoV1.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/producer/dto/NavBrukerDtoV1.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.person.service.kafka.producer.dto
 
+import no.nav.amt.person.service.person.model.Adresse
 import java.util.UUID
 
 data class NavBrukerDtoV1 (
@@ -13,4 +14,5 @@ data class NavBrukerDtoV1 (
 	val telefon: String?,
 	val epost: String?,
 	val erSkjermet: Boolean,
+	val adresse: Adresse?
 )

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBruker.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBruker.kt
@@ -3,6 +3,7 @@ package no.nav.amt.person.service.nav_bruker
 import no.nav.amt.person.service.nav_ansatt.NavAnsatt
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerUpsert
 import no.nav.amt.person.service.nav_enhet.NavEnhet
+import no.nav.amt.person.service.person.model.Adresse
 import no.nav.amt.person.service.person.model.Person
 import java.util.*
 
@@ -14,6 +15,7 @@ data class NavBruker(
 	val telefon: String?,
 	val epost: String?,
 	val erSkjermet: Boolean,
+	val adresse: Adresse?
 ) {
 	fun toUpsert(
 		id: UUID = this.id,
@@ -23,6 +25,7 @@ data class NavBruker(
 		telefon: String? = this.telefon,
 		epost: String? = this.epost,
 		erSkjermet: Boolean = this.erSkjermet,
+		adresse: Adresse? = this.adresse
 	) = NavBrukerUpsert(
 		id = id,
 		personId = personId,
@@ -31,6 +34,7 @@ data class NavBruker(
 		telefon = telefon,
 		epost = epost,
 		erSkjermet = erSkjermet,
+		adresse = adresse
 	)
 
 }

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepository.kt
@@ -5,6 +5,8 @@ import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerUpsert
 import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
+import no.nav.amt.person.service.person.model.Adresse
+import no.nav.amt.person.service.utils.JsonUtils.fromJsonString
 import no.nav.amt.person.service.utils.getNullableUUID
 import no.nav.amt.person.service.utils.getUUID
 import no.nav.amt.person.service.utils.sqlParameters
@@ -54,6 +56,7 @@ class NavBrukerRepository(
 			telefon = rs.getString("nav_bruker.telefon"),
 			epost = rs.getString("nav_bruker.epost"),
 			erSkjermet = rs.getBoolean("nav_bruker.er_skjermet"),
+			adresse = rs.getString("nav_bruker.adresse")?.let { fromJsonString<Adresse>(it) },
 			createdAt = rs.getTimestamp("nav_bruker.created_at").toLocalDateTime(),
 			modifiedAt = rs.getTimestamp("nav_bruker.modified_at").toLocalDateTime()
 		)
@@ -106,7 +109,8 @@ class NavBrukerRepository(
 				nav_enhet_id,
 				telefon,
 				epost,
-				er_skjermet
+				er_skjermet,
+				adresse
 			) values (
 				:id,
 				:personId,
@@ -114,13 +118,15 @@ class NavBrukerRepository(
 				:navEnhetId,
 				:telefon,
 				:epost,
-				:erSkjermet
+				:erSkjermet,
+				:adresse
 			) on conflict(person_id) do update set
 				nav_veileder_id = :navVeilederId,
 				nav_enhet_id = :navEnhetId,
 				telefon = :telefon,
 				epost = :epost,
 				er_skjermet = :erSkjermet,
+				adresse = :adresse,
 				modified_at = current_timestamp
 				where nav_bruker.id = :id
 		""".trimIndent()
@@ -133,6 +139,7 @@ class NavBrukerRepository(
 			"telefon" to bruker.telefon,
 			"epost" to bruker.epost,
 			"erSkjermet" to bruker.erSkjermet,
+			"adresse" to bruker.adresse?.toPGObject()
 		)
 
 		template.update(sql, parameters)
@@ -148,6 +155,7 @@ class NavBrukerRepository(
 				   nav_bruker.telefon as "nav_bruker.telefon",
 				   nav_bruker.epost as "nav_bruker.epost",
 				   nav_bruker.er_skjermet as "nav_bruker.er_skjermet",
+				   nav_bruker.adresse as "nav_bruker.adresse",
 				   nav_bruker.created_at as "nav_bruker.created_at",
 				   nav_bruker.modified_at as "nav_bruker.modified_at",
 				   person.personident as "person.personident",

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
@@ -71,6 +71,7 @@ class NavBrukerService(
 			telefon = kontaktinformasjon?.telefonnummer ?:  personOpplysninger.telefonnummer,
 			epost = kontaktinformasjon?.epost,
 			erSkjermet = erSkjermet,
+			adresse = personOpplysninger.adresse
 		)
 
 		upsert(navBruker)

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerService.kt
@@ -119,6 +119,12 @@ class NavBrukerService(
 		}
 	}
 
+	fun oppdaterAdresse(personer: List<Person>) {
+		personer.forEach {person ->
+			oppdaterAdresse(person.personident)
+		}
+	}
+
 	private fun oppdaterKontaktinformasjon(personident: String) {
 		val bruker = repository.get(personident)?.toModel() ?: return
 
@@ -136,6 +142,25 @@ class NavBrukerService(
 		if (bruker.telefon == telefon && bruker.epost == krrKontaktinfo.epost) return
 
 		upsert(bruker.copy(telefon = telefon, epost = krrKontaktinfo.epost))
+	}
+
+	private fun oppdaterAdresse(personident: String) {
+		val bruker = repository.get(personident)?.toModel() ?: return
+
+		val personOpplysninger = try {
+			pdlClient.hentPerson(personident)
+		} catch (e: Exception) {
+			val feilmelding = "Klarte ikke hente person fra PDL ved oppdatert adresse: ${e.message}"
+
+			if (EnvUtils.isDev()) log.info(feilmelding)
+			else log.error(feilmelding)
+
+			return
+		}
+
+		if (bruker.adresse == personOpplysninger.adresse) return
+
+		upsert(bruker.copy(adresse = personOpplysninger.adresse))
 	}
 
 	fun slettBrukere(personer: List<Person>) {

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/dbo/NavBrukerDbo.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/dbo/NavBrukerDbo.kt
@@ -4,6 +4,7 @@ import no.nav.amt.person.service.nav_ansatt.NavAnsattDbo
 import no.nav.amt.person.service.nav_bruker.NavBruker
 import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
+import no.nav.amt.person.service.person.model.Adresse
 import java.time.LocalDateTime
 import java.util.*
 
@@ -15,6 +16,7 @@ data class NavBrukerDbo(
 	val telefon: String?,
 	val epost: String?,
 	val erSkjermet: Boolean,
+	val adresse: Adresse?,
 	val createdAt: LocalDateTime,
 	val modifiedAt: LocalDateTime
 ) {
@@ -26,5 +28,6 @@ data class NavBrukerDbo(
 		telefon,
 		epost,
 		erSkjermet,
+		adresse
 	)
 }

--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/dbo/NavBrukerUpsert.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/dbo/NavBrukerUpsert.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.person.service.nav_bruker.dbo
 
+import no.nav.amt.person.service.person.model.Adresse
 import java.util.*
 
 data class NavBrukerUpsert(
@@ -10,4 +11,5 @@ data class NavBrukerUpsert(
 	val telefon: String?,
 	val epost: String?,
 	val erSkjermet: Boolean,
+	val adresse: Adresse?
 )

--- a/src/main/kotlin/no/nav/amt/person/service/person/model/Adresse.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/model/Adresse.kt
@@ -1,10 +1,18 @@
 package no.nav.amt.person.service.person.model
 
+import no.nav.amt.person.service.utils.JsonUtils.objectMapper
+import org.postgresql.util.PGobject
+
 data class Adresse(
 	val bostedsadresse: Bostedsadresse?,
 	val oppholdsadresse: Oppholdsadresse?,
 	val kontaktadresse: Kontaktadresse?
-)
+) {
+	fun toPGObject() = PGobject().also {
+		it.type = "json"
+		it.value = objectMapper.writeValueAsString(this)
+	}
+}
 
 data class Bostedsadresse(
 	val coAdressenavn: String?,

--- a/src/main/kotlin/no/nav/amt/person/service/person/model/Adresse.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/person/model/Adresse.kt
@@ -1,0 +1,46 @@
+package no.nav.amt.person.service.person.model
+
+data class Adresse(
+	val bostedsadresse: Bostedsadresse?,
+	val oppholdsadresse: Oppholdsadresse?,
+	val kontaktadresse: Kontaktadresse?
+)
+
+data class Bostedsadresse(
+	val coAdressenavn: String?,
+	val vegadresse: Vegadresse?,
+	val matrikkeladresse: Matrikkeladresse?
+)
+
+data class Oppholdsadresse(
+	val coAdressenavn: String?,
+	val vegadresse: Vegadresse?,
+	val matrikkeladresse: Matrikkeladresse?
+)
+
+data class Kontaktadresse(
+	val coAdressenavn: String?,
+	val vegadresse: Vegadresse?,
+	val postboksadresse: Postboksadresse?
+)
+
+data class Vegadresse(
+	val husnummer: String?,
+	val husbokstav: String?,
+	val adressenavn: String?,
+	val tilleggsnavn: String?,
+	val postnummer: String,
+	val poststed: String
+)
+
+data class Matrikkeladresse(
+	val tilleggsnavn: String?,
+	val postnummer: String,
+	val poststed: String
+)
+
+data class Postboksadresse(
+	val postboks: String,
+	val postnummer: String,
+	val poststed: String
+)

--- a/src/main/kotlin/no/nav/amt/person/service/poststed/PoststedRepository.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/poststed/PoststedRepository.kt
@@ -76,6 +76,22 @@ class PoststedRepository(
 			resultSet.toPostnummer()
 		}
 	}
+
+	fun getPoststeder(postnummer: List<String>): List<Postnummer> {
+		if (postnummer.isEmpty()) {
+			return emptyList()
+		}
+		return namedParameterJdbcTemplate.query(
+			"""
+				SELECT postnummer,
+				poststed
+				FROM postnummer WHERE postnummer in (:postnummer);
+				""",
+			mapOf("postnummer" to postnummer)
+		) { resultSet, _ ->
+			resultSet.toPostnummer()
+		}
+	}
 }
 
 private fun ResultSet.toPostnummer(): Postnummer =

--- a/src/main/resources/db/migration/V14__navbruker_add_adresse.sql
+++ b/src/main/resources/db/migration/V14__navbruker_add_adresse.sql
@@ -1,0 +1,1 @@
+alter table nav_bruker add column adresse JSONB;

--- a/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/clients/pdl/PdlClientTestData.kt
@@ -91,6 +91,23 @@ object PdlClientTestData {
 						{
 							"gradering": "FORTROLIG"
 						}
+					],
+					"bostedsadresse": [
+						{
+							"matrikkeladresse": {
+								"tilleggsnavn": "Storgården",
+								"postnummer": "0484"
+							}
+						}
+					],
+					"oppholdsadresse": [],
+					"kontaktadresse": [
+						{
+							"postboksadresse": {
+								"postboks": "Postboks 1234",
+								"postnummer": "0484"
+							}
+						}
 					]
 				},
 				"hentIdenter": {

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -8,8 +8,12 @@ import no.nav.amt.person.service.person.dbo.PersonDbo
 import no.nav.amt.person.service.person.dbo.PersonidentDbo
 import no.nav.amt.person.service.person.model.Adresse
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
+import no.nav.amt.person.service.person.model.Bostedsadresse
 import no.nav.amt.person.service.person.model.IdentType
+import no.nav.amt.person.service.person.model.Kontaktadresse
+import no.nav.amt.person.service.person.model.Matrikkeladresse
 import no.nav.amt.person.service.person.model.Personident
+import no.nav.amt.person.service.person.model.Vegadresse
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -88,7 +92,7 @@ object TestData {
         telefon: String? = null,
         adressebeskyttelseGradering: AdressebeskyttelseGradering? = null,
         identer: List<Personident> = listOf(Personident(person.personident, false, IdentType.FOLKEREGISTERIDENT)),
-		adresse: Adresse? = null
+		adresse: Adresse? = lagAdresse()
 	) = PdlPerson(
 		fornavn = person.fornavn,
 		mellomnavn = person.mellomnavn,
@@ -107,4 +111,30 @@ object TestData {
 		modifiedAt: LocalDateTime = LocalDateTime.now(),
 		createdAt: LocalDateTime = LocalDateTime.now()
 	) = PersonidentDbo(ident, personId, historisk, type, modifiedAt, createdAt)
+
+	private fun lagAdresse(): Adresse =
+		Adresse(
+			bostedsadresse = Bostedsadresse(
+				coAdressenavn = "C/O Gutterommet",
+				vegadresse = null,
+				matrikkeladresse = Matrikkeladresse(
+					tilleggsnavn = "Gården",
+					postnummer = "0484",
+					poststed = "OSLO"
+				)
+			),
+			oppholdsadresse = null,
+			kontaktadresse = Kontaktadresse(
+				coAdressenavn = null,
+				vegadresse = Vegadresse(
+					husnummer = "1",
+					husbokstav = null,
+					adressenavn = "Gate",
+					tilleggsnavn = null,
+					postnummer = "1234",
+					poststed = "MOSS"
+				),
+				postboksadresse = null
+			)
+		)
 }

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -6,6 +6,7 @@ import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
 import no.nav.amt.person.service.nav_enhet.NavEnhetDbo
 import no.nav.amt.person.service.person.dbo.PersonDbo
 import no.nav.amt.person.service.person.dbo.PersonidentDbo
+import no.nav.amt.person.service.person.model.Adresse
 import no.nav.amt.person.service.person.model.AdressebeskyttelseGradering
 import no.nav.amt.person.service.person.model.IdentType
 import no.nav.amt.person.service.person.model.Personident
@@ -86,6 +87,7 @@ object TestData {
         telefon: String? = null,
         adressebeskyttelseGradering: AdressebeskyttelseGradering? = null,
         identer: List<Personident> = listOf(Personident(person.personident, false, IdentType.FOLKEREGISTERIDENT)),
+		adresse: Adresse? = null
 	) = PdlPerson(
 		fornavn = person.fornavn,
 		mellomnavn = person.mellomnavn,
@@ -93,6 +95,7 @@ object TestData {
 		telefonnummer = telefon,
 		adressebeskyttelseGradering = adressebeskyttelseGradering,
 		identer = identer,
+		adresse = adresse
 	)
 
 	fun lagPersonident(

--- a/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/data/TestData.kt
@@ -78,9 +78,10 @@ object TestData {
 		telefon: String? = "77788999",
 		epost: String? = "nav_bruker@gmail.com",
 		erSkjermet: Boolean = false,
+		adresse: Adresse? = null,
 		createdAt: LocalDateTime = LocalDateTime.now(),
 		modifiedAt: LocalDateTime = LocalDateTime.now(),
-	) = NavBrukerDbo(id, person, navVeileder, navEnhet, telefon, epost, erSkjermet, createdAt, modifiedAt)
+	) = NavBrukerDbo(id, person, navVeileder, navEnhet, telefon, epost, erSkjermet, adresse, createdAt, modifiedAt)
 
 	fun lagPdlPerson(
         person: PersonDbo,

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavBrukerProducerTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/producer/NavBrukerProducerTest.kt
@@ -95,6 +95,7 @@ class NavBrukerProducerTest: IntegrationTestBase() {
 				telefon = navBruker.telefon,
 				epost = navBruker.epost,
 				erSkjermet = navBruker.erSkjermet,
+				adresse = navBruker.adresse
 			)
 		)
 	}

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
@@ -158,7 +158,31 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 							listOf(PdlQueries.Attribute.Adressebeskyttelse(gradering = mockPdlPerson.adressebeskyttelseGradering.toString()))
 						} else {
 							emptyList()
-						}
+						},
+						bostedsadresse = listOf(
+							PdlQueries.Attribute.Bostedsadresse(
+								coAdressenavn = "C/O Mamma",
+								vegadresse = PdlQueries.Attribute.Vegadresse(
+									husnummer = "7",
+									husbokstav = null,
+									adressenavn = "Gateveien",
+									tilleggsnavn = "Gården",
+									postnummer = "0484"
+								),
+								matrikkeladresse = null
+							)
+						),
+						oppholdsadresse = emptyList(),
+						kontaktadresse = listOf(
+							PdlQueries.Attribute.Kontaktadresse(
+								coAdressenavn = null,
+								vegadresse = null,
+								postboksadresse = PdlQueries.Attribute.Postboksadresse(
+									postboks = "Postboks 1234",
+									postnummer = "0484"
+								)
+							)
+						)
 					),
 					PdlQueries.HentPerson.HentIdenter(listOf(PdlQueries.Attribute.Ident(personident, false, "FOLKEREGISTERIDENT")))
 				),

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/NavBrukerRepositoryTest.kt
@@ -5,6 +5,9 @@ import no.nav.amt.person.service.data.TestData
 import no.nav.amt.person.service.data.TestDataRepository
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerDbo
 import no.nav.amt.person.service.nav_bruker.dbo.NavBrukerUpsert
+import no.nav.amt.person.service.person.model.Adresse
+import no.nav.amt.person.service.person.model.Kontaktadresse
+import no.nav.amt.person.service.person.model.Vegadresse
 import no.nav.amt.person.service.utils.DbTestDataUtils
 import no.nav.amt.person.service.utils.SingletonPostgresContainer
 import no.nav.amt.person.service.utils.shouldBeCloseTo
@@ -132,7 +135,8 @@ class NavBrukerRepositoryTest {
 			bruker.navEnhet?.id,
 			bruker.telefon,
 			bruker.epost,
-			bruker.erSkjermet
+			bruker.erSkjermet,
+			bruker.adresse
 		))
 
 		val faktiskBruker = repository.get(bruker.id)
@@ -158,7 +162,23 @@ class NavBrukerRepositoryTest {
 			navEnhetId = null,
 			telefon = "ny telefon",
 			epost = "ny@epost.no",
-			erSkjermet = true
+			erSkjermet = true,
+			adresse = Adresse(
+				bostedsadresse = null,
+				oppholdsadresse = null,
+				kontaktadresse = Kontaktadresse(
+					coAdressenavn = null,
+					vegadresse = Vegadresse(
+						husnummer = "1",
+						husbokstav = null,
+						adressenavn = "Gate",
+						tilleggsnavn = null,
+						postnummer = "1234",
+						poststed = "MOSS"
+					),
+					postboksadresse = null
+				)
+			)
 		)
 
 		repository.upsert(upsert)
@@ -171,6 +191,11 @@ class NavBrukerRepositoryTest {
 
 		faktiskBruker.telefon shouldBe upsert.telefon
 		faktiskBruker.epost shouldBe upsert.epost
+
+		faktiskBruker.adresse?.kontaktadresse?.vegadresse?.husnummer shouldBe "1"
+		faktiskBruker.adresse?.kontaktadresse?.vegadresse?.adressenavn shouldBe "Gate"
+		faktiskBruker.adresse?.kontaktadresse?.vegadresse?.postnummer shouldBe "1234"
+		faktiskBruker.adresse?.kontaktadresse?.vegadresse?.poststed shouldBe "MOSS"
 
 		faktiskBruker.createdAt shouldBeEqualTo bruker.createdAt
 		faktiskBruker.modifiedAt shouldBeCloseTo LocalDateTime.now()

--- a/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/person/PersonServiceTest.kt
@@ -53,7 +53,8 @@ class PersonServiceTest {
 			identer = listOf(
 				Personident(ident = personident, historisk = false, type = identType),
 				Personident(ident = TestData.randomIdent(), historisk = true, type = identType),
-			)
+			),
+			adresse = null
 		)
 
 		every { pdlClient.hentPerson(personident) } returns pdlPerson


### PR DESCRIPTION
NAV-bruker skal inneholde adresse hvis den finnes, både i databasen, på kafka og i api-respons. Adressen oppdateres ved endring på topic (leesah-topicen mangler bostedsadresse, så alle adresseendringer trigger et kall mot PDL der vi oppdaterer adressen). 

https://trello.com/c/5iUmYxs5/1063-amt-person-hente-og-lagre-adresse-fra-pdl-for-navbrukere-jsonb-og-sende-med-adresse-p%C3%A5-topic-nav-bruker-personalia-v1-og-lytte-p