### PR TITLE
overstyrer logback-versjon pga sårbarhet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ val micrometerVersion = "1.12.1"
 val postgresVersion = "42.7.1"
 val mockOauth2ServerVersion = "2.1.0"
 
+extra["logback.version"] = "1.4.12"
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")


### PR DESCRIPTION
Ved å gjøre det på denne måten lar jeg spring boot fortsatt styre det meste bortsett fra selve versjonen. 