### PR TITLE
fjerner graceperiode for oppfølgingsperiode

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/nav_bruker/Oppfolgingsperiode.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/nav_bruker/Oppfolgingsperiode.kt
@@ -11,8 +11,7 @@ data class Oppfolgingsperiode(
 ) {
 	fun erAktiv(): Boolean {
 		val now = LocalDate.now()
-		val antallDagerGracePeriod = 28L
-		return !(now.isBefore(startdato.toLocalDate()) || (sluttdato != null && now.isAfter(sluttdato.toLocalDate().plusDays(antallDagerGracePeriod))))
+		return !(now.isBefore(startdato.toLocalDate()) || (sluttdato != null && !now.isBefore(sluttdato.toLocalDate())))
 	}
 }
 

--- a/src/test/kotlin/no/nav/amt/person/service/nav_bruker/AktivOppfolgingsperiodeTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/nav_bruker/AktivOppfolgingsperiodeTest.kt
@@ -42,20 +42,20 @@ class AktivOppfolgingsperiodeTest {
 	}
 
 	@Test
-	fun `harAktivOppfolgingsperiode - startdato passert, sluttdato for 25 dager siden - returnerer true`() {
+	fun `harAktivOppfolgingsperiode - startdato passert, sluttdato i dag - returnerer false`() {
 		val oppfolgingsperiode = TestData.lagOppfolgingsperiode(
 			startdato = LocalDateTime.now().minusYears(1),
-			sluttdato = LocalDateTime.now().minusDays(25)
+			sluttdato = LocalDateTime.now()
 		)
 
-		harAktivOppfolgingsperiode(listOf(oppfolgingsperiode)) shouldBe true
+		harAktivOppfolgingsperiode(listOf(oppfolgingsperiode)) shouldBe false
 	}
 
 	@Test
-	fun `harAktivOppfolgingsperiode - startdato passert, sluttdato for 29 dager siden - returnerer false`() {
+	fun `harAktivOppfolgingsperiode - startdato passert, sluttdato for 2 dager siden - returnerer false`() {
 		val oppfolgingsperiode = TestData.lagOppfolgingsperiode(
 			startdato = LocalDateTime.now().minusYears(1),
-			sluttdato = LocalDateTime.now().minusDays(29)
+			sluttdato = LocalDateTime.now().minusDays(2)
 		)
 
 		harAktivOppfolgingsperiode(listOf(oppfolgingsperiode)) shouldBe false


### PR DESCRIPTION
https://trello.com/c/CotpcN88/1628-hvis-bruker-g%C3%A5r-ut-av-oppf%C3%B8lging-skal-evt-kladd-slettes

Siden oppfølgingsperiode uansett ikke skal kunne avsluttes når man har aktive deltakelser fjerner vi graceperioden. 