### PR TITLE
Hent navn fra pdl-api ved melding om navnendring

### DIFF
--- a/src/main/kotlin/no/nav/amt/person/service/kafka/ingestor/LeesahIngestor.kt
+++ b/src/main/kotlin/no/nav/amt/person/service/kafka/ingestor/LeesahIngestor.kt
@@ -4,7 +4,6 @@ import no.nav.amt.person.service.nav_bruker.NavBrukerService
 import no.nav.amt.person.service.person.PersonService
 import no.nav.person.pdl.leesah.Personhendelse
 import no.nav.person.pdl.leesah.adressebeskyttelse.Adressebeskyttelse
-import no.nav.person.pdl.leesah.navn.Navn
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -25,7 +24,7 @@ class LeesahIngestor(
 
 	fun ingest(personhendelse: Personhendelse) {
 		when (personhendelse.opplysningstype) {
-			OpplysningsType.NAVN_V1.toString() -> handterNavn(personhendelse.personidenter, personhendelse.navn)
+			OpplysningsType.NAVN_V1.toString() -> handterNavn(personhendelse.personidenter)
 			OpplysningsType.ADRESSEBESKYTTELSE_V1.toString() ->
 				handterAdressebeskyttelse(personhendelse.personidenter, personhendelse.adressebeskyttelse)
 			OpplysningsType.BOSTEDSADRESSE_V1.toString() -> handterAdresse(personhendelse.personidenter)
@@ -48,22 +47,13 @@ class LeesahIngestor(
 		}
 	}
 
-	private fun handterNavn(personidenter: List<String>, navn: Navn?) {
-		if (navn == null) {
-			log.warn("Mottok melding med opplysningstype Navn fra pdl-leesah men navn manglet")
-			return
-		}
-
+	private fun handterNavn(personidenter: List<String>) {
 		val personer = personService.hentPersoner(personidenter)
 
 		if (personer.isEmpty()) return
 
 		personer.forEach { person ->
-			personService.upsert(person.copy(
-				fornavn = navn.fornavn,
-				mellomnavn = navn.mellomnavn,
-				etternavn = navn.etternavn,
-			))
+			personService.oppdaterNavn(person)
 		}
 	}
 

--- a/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/kafka/ingestor/LeesahIngestorTest.kt
@@ -39,6 +39,12 @@ class LeesahIngestorTest : IntegrationTestBase() {
 
 		mockPdlHttpServer.mockHentTelefon(person.personident, null)
 
+		mockPdlHttpServer.mockHentPerson(person.copy(
+			fornavn = nyttFornavn,
+			mellomnavn = nyttMellomnavn,
+			etternavn = nyttEtternavn
+		))
+
 		val msg = KafkaMessageCreator.lagPersonhendelseNavn(
 			personidenter = listOf(person.personident),
 			fornavn = nyttFornavn,

--- a/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/integration/mock/servers/MockPdlHttpServer.kt
@@ -152,7 +152,7 @@ class MockPdlHttpServer : MockHttpServer(name = "PdlHttpServer") {
 				errors = null,
 				data = PdlQueries.HentPerson.ResponseData(
 					PdlQueries.HentPerson.HentPerson(
-						navn = listOf(PdlQueries.Attribute.Navn(mockPdlPerson.fornavn, null, mockPdlPerson.etternavn)),
+						navn = listOf(PdlQueries.Attribute.Navn(mockPdlPerson.fornavn, mockPdlPerson.mellomnavn, mockPdlPerson.etternavn)),
 						telefonnummer = listOf(PdlQueries.Attribute.Telefonnummer("47", "12345678", 1)),
 						adressebeskyttelse = if (mockPdlPerson.adressebeskyttelseGradering != null) {
 							listOf(PdlQueries.Attribute.Adressebeskyttelse(gradering = mockPdlPerson.adressebeskyttelseGradering.toString()))


### PR DESCRIPTION
Meldinger om navn kommer i tilfeldige rekkefølger, spesiellt når man endrer navn eller ident i dolly, så det er fort gjort at man ender opp med et gammelt navn hvis man ikke spør apiet direkte.