### PR TITLE
Byttet ut 'management.endpoint.prometheus.enabled' som er deprikert m…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,7 @@
 spring.main.banner-mode=off
 server.shutdown=graceful
 
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=read_only
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoints.web.base-path=/internal

--- a/src/test/kotlin/no/nav/amt/person/service/ActuatorTest.kt
+++ b/src/test/kotlin/no/nav/amt/person/service/ActuatorTest.kt
@@ -1,0 +1,61 @@
+package no.nav.amt.person.service
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import no.nav.amt.person.service.integration.IntegrationTestBase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalManagementPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.util.UriComponentsBuilder
+
+class ActuatorTest(
+	@LocalManagementPort private val managementPort: Int,
+	private val restTemplate: TestRestTemplate,
+) : IntegrationTestBase() {
+
+	@ParameterizedTest(name = "{0} probe skal returnere OK og status = UP")
+	@ValueSource(strings = ["liveness", "readiness"])
+	fun probe_skal_returnere_OK_og_status_UP(probeName: String) {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/health/{probeName}")
+				.buildAndExpand(managementPort, probeName)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+        assertSoftly(response) {
+            statusCode shouldBe HttpStatus.OK
+            body shouldBe "{\"status\":\"UP\"}"
+        }
+	}
+
+	@Test
+	fun `Prometheus-endepunktet skal returnere OK`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/prometheus")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.OK
+	}
+
+	@Test
+	fun `Metrics-endepunktet skal returnere NOT_FOUND`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/metrics")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.NOT_FOUND
+	}
+}


### PR DESCRIPTION
- Byttet ut `management.endpoint.prometheus.enabled` som er deprikert med `management.endpoint.prometheus.access`. [Spring-Boot-3.4-Configuration-Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Configuration-Changelog)
- Fjernet deprikert `management.endpoint.metrics.enabled=true` fordi denne ikke er med i `management.endpoints.web.exposure.include` og er dermed overflødig.
- Lagt til tester for actuator-endepunktene

Det anbefales å konfigurere `management.server.port` til annen port enn for øvrige endepunkter.
