### PR TITLE
Bump dependencies - 20250909075821

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 
 val commonVersion = "3.2025.09.03_08.33-728ff4acbfdb"
 val okhttp3Version = "5.1.0"
-val kotestVersion = "5.9.1"
+val kotestVersion = "6.0.3"
 val poaoTilgangVersion = "2025.07.04_08.56-814fa50f6740"
 val testcontainersVersion = "1.21.3"
 val tokenSupportVersion = "5.0.36"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250909075821 branch:

## Successfully Rebased PRs
- [Bump kotestVersion from 5.9.1 to 6.0.3](https://github.com/navikt/amt-person-service/pull/466)
- [Bump no.nav.security:mock-oauth2-server from 2.2.1 to 2.3.0](https://github.com/navikt/amt-person-service/pull/465)
- [Bump commonVersion from 3.2025.08.19_06.12-48301d0f4239 to 3.2025.09.03_08.33-728ff4acbfdb](https://github.com/navikt/amt-person-service/pull/464)
- [Bump no.nav.security:token-validation-spring from 5.0.34 to 5.0.36](https://github.com/navikt/amt-person-service/pull/463)
- [Bump com.fasterxml.jackson.module:jackson-module-kotlin from 2.19.2 to 2.20.0](https://github.com/navikt/amt-person-service/pull/454)


